### PR TITLE
Reconnect On Logout

### DIFF
--- a/email/fetcher.go
+++ b/email/fetcher.go
@@ -26,23 +26,29 @@ type (
 	// Fetcher is an object that will periodically scan an inbox and persist the
 	// missing messages in the database.
 	Fetcher struct {
-		staticContext     context.Context
-		staticDatabase    *database.AbuseScannerDB
-		staticEmailClient *client.Client
-		staticLogger      *logrus.Entry
-		staticMailbox     string
-		staticWaitGroup   sync.WaitGroup
+		staticContext                context.Context
+		staticDatabase               *database.AbuseScannerDB
+		staticEmailClient            *client.Client
+		staticEmailClientReconnectFn ReconnectFn
+		staticLogger                 *logrus.Entry
+		staticMailbox                string
+		staticWaitGroup              sync.WaitGroup
 	}
+
+	// ReconnectFn is a helper type that describes a function that reconnects
+	// the email client in case it has dropped its connection.
+	ReconnectFn func() error
 )
 
 // NewFetcher creates a new fetcher.
-func NewFetcher(ctx context.Context, database *database.AbuseScannerDB, emailClient *client.Client, mailbox string, logger *logrus.Logger) *Fetcher {
+func NewFetcher(ctx context.Context, database *database.AbuseScannerDB, emailClient *client.Client, mailbox string, reconnectFn ReconnectFn, logger *logrus.Logger) *Fetcher {
 	return &Fetcher{
-		staticContext:     ctx,
-		staticDatabase:    database,
-		staticEmailClient: emailClient,
-		staticLogger:      logger.WithField("module", "Fetcher"),
-		staticMailbox:     mailbox,
+		staticContext:                ctx,
+		staticDatabase:               database,
+		staticEmailClient:            emailClient,
+		staticEmailClientReconnectFn: reconnectFn,
+		staticLogger:                 logger.WithField("module", "Fetcher"),
+		staticMailbox:                mailbox,
 	}
 }
 
@@ -141,6 +147,14 @@ func (f *Fetcher) threadedFetchMessages() {
 
 		// select the mailbox in every iteration (the uid validity might change)
 		mailbox, err := f.staticEmailClient.Select(f.staticMailbox, false)
+		if err == client.ErrNotLoggedIn {
+			logger.Debugln("Client not logged in, try reconnecting...")
+			err = f.staticEmailClientReconnectFn()
+			if err == nil {
+				logger.Debugln("reconnect succeeded, selecting mailbox")
+				mailbox, err = f.staticEmailClient.Select(f.staticMailbox, false)
+			}
+		}
 		if err != nil {
 			logger.Errorf("Failed selecting mailbox %v, error %v", f.staticMailbox, err)
 			continue

--- a/email/fetcher.go
+++ b/email/fetcher.go
@@ -190,6 +190,11 @@ func (f *Fetcher) threadedFetchMessages() {
 				logger.Errorf("Failed fetching message %v, error %v", msgUid, err)
 			}
 		}
+
+		// TODO: remove - tmp logout to see if reconnect works
+		if err := f.staticEmailClient.Logout(); err != nil {
+			logger.Errorf("failed to logout, err: %v", err)
+		}
 	}
 }
 

--- a/email/fetcher.go
+++ b/email/fetcher.go
@@ -148,8 +148,8 @@ func (f *Fetcher) threadedFetchMessages() {
 		// select the mailbox in every iteration (the uid validity might change)
 		mailbox, err := f.staticEmailClient.Select(f.staticMailbox, false)
 
-		// try reconnecting if the client is not loggd in
-		if err == client.ErrNotLoggedIn {
+		// try reconnecting on error
+		if err != nil {
 			logger.Debugln("Failed selecting mailbox, reconnecting")
 			if err := f.staticEmailClientReconnectFn(); err != nil {
 				logger.Errorf("Failed reconnecting, error %v\n", err)

--- a/email/fetcher.go
+++ b/email/fetcher.go
@@ -190,11 +190,6 @@ func (f *Fetcher) threadedFetchMessages() {
 				logger.Errorf("Failed fetching message %v, error %v", msgUid, err)
 			}
 		}
-
-		// TODO: remove - tmp logout to see if reconnect works
-		if err := f.staticEmailClient.Logout(); err != nil {
-			logger.Errorf("failed to logout, err: %v", err)
-		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/emersion/go-imap/client"
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
 	"gitlab.com/NebulousLabs/errors"
@@ -87,12 +86,9 @@ func main() {
 		}
 	}()
 
+	// define a function that reconnects the email client
 	reconnectFn := func() error {
-		err = mail.Logout()
-		if err != client.ErrAlreadyLoggedOut {
-			return err
-		}
-
+		_ = mail.Logout() // attempt logout and don't care about the error
 		mail, err = email.NewClient(emailServer, emailUsername, emailPassword)
 		if err != nil {
 			return err
@@ -102,7 +98,7 @@ func main() {
 
 	// create a new mail fetcher, it downloads the emails
 	logger.Info("Initializing email fetcher...")
-	fetcher := email.NewFetcher(ctx, db, mail, abuseMailbox, logger)
+	fetcher := email.NewFetcher(ctx, db, mail, abuseMailbox, reconnectFn, logger)
 	err = fetcher.Start()
 	if err != nil {
 		log.Fatal("Failed to start the email fetcher, err: ", err)

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/emersion/go-imap/client"
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
 	"gitlab.com/NebulousLabs/errors"
@@ -85,6 +86,19 @@ func main() {
 			logger.Infof("Failed logging out, error: %v", err)
 		}
 	}()
+
+	reconnectFn := func() error {
+		err = mail.Logout()
+		if err != client.ErrAlreadyLoggedOut {
+			return err
+		}
+
+		mail, err = email.NewClient(emailServer, emailUsername, emailPassword)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// create a new mail fetcher, it downloads the emails
 	logger.Info("Initializing email fetcher...")


### PR DESCRIPTION
# PULL REQUEST

## Overview
On production, we're seeing the abuse scanner erroring out after a while with the error message

`abuse               | time="2022-01-11 08:50:57" level=error msg="Failed selecting mailbox Abuse Scanner, error Not logged in" module=Fetcher`

It's kind of annoying to try and reproduce the exact error but I believe the solution is to simply reconnect when we find the client is no longer logged in. It makes sense that this happens from time to time. Connections can drop or time out for multiple reasons, I feel (naively) attempting a reconnect when we notice the client is no longer logged in is the mechanism we want to have.

I am currently testing this on `eu-pol-5`.

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings

## Issues Closed
N/A