### PR TITLE
Abuse Scanner Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,46 @@ ifneq ("$(OS)","Windows_NT")
 	go mod tidy
 endif
 
+# Credentials and port we are going to use for our test MongoDB instance.
+MONGO_USER=admin
+MONGO_PASSWORD=aO4tV5tC1oU3oQ7u
+MONGO_PORT=37017
+
+# call_mongo is a helper function that executes a query in an `eval` call to the
+# test mongo instance.
+define call_mongo
+    docker exec blocker-mongo-test-db mongo -u $(MONGO_USER) -p $(MONGO_PASSWORD) --port $(MONGO_PORT) --eval $(1)
+endef
+
+# start-mongo starts a local mongoDB container with no persistence.
+# We first prepare for the start of the container by making sure the test
+# keyfile has the right permissions, then we clear any potential leftover
+# containers with the same name. After we start the container we initialise a
+# single node replica set. All the output is discarded because it's noisy and
+# if it causes a failure we'll immediately know where it is even without it.
+start-mongo:
+	-docker stop blocker-mongo-test-db 1>/dev/null 2>&1
+	-docker rm blocker-mongo-test-db 1>/dev/null 2>&1
+	docker run \
+     --rm \
+     --detach \
+     --name blocker-mongo-test-db \
+     -p $(MONGO_PORT):$(MONGO_PORT) \
+     -e MONGO_INITDB_ROOT_USERNAME=$(MONGO_USER) \
+     -e MONGO_INITDB_ROOT_PASSWORD=$(MONGO_PASSWORD) \
+	mongo:4.4.1 mongod --port=$(MONGO_PORT) --replSet=skynet 1>/dev/null 2>&1
+	# wait for mongo to start before we try to configure it
+	status=1 ; while [[ $$status -gt 0 ]]; do \
+		sleep 1 ; \
+		$(call call_mongo,"") 1>/dev/null 2>&1 ; \
+		status=$$? ; \
+	done
+	# Initialise a single node replica set.
+	$(call call_mongo,"rs.initiate({_id: \"skynet\", members: [{ _id: 0, host: \"localhost:$(MONGO_PORT)\" }]})") 1>/dev/null 2>&1
+
+stop-mongo:
+	-docker stop blocker-mongo-test-db
+	
 # release builds and installs release binaries.
 release:
 	go install -tags='netgo' -ldflags='-s -w $(ldflags)' $(release-pkgs)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ that define whether a certain module has handled the email in question, e.g.
 - ABUSE_SPONSOR=
 - BLOCKER_HOST=
 - BLOCKER_PORT=
-- BLOCKER_AUTH_HEADER=
 - EMAIL_SERVER=
 - EMAIL_USERNAME=
 - EMAIL_PASSWORD=

--- a/database/abusescanner.go
+++ b/database/abusescanner.go
@@ -87,6 +87,7 @@ type (
 
 		Skip bool `bson:"skip"`
 
+		InsertedBy string    `bson:"inserted_by"`
 		InsertedAt time.Time `bson:"inserted_at"`
 		Finalized  bool      `bson:"finalized"`
 	}
@@ -119,6 +120,9 @@ func (a AbuseEmail) String() string {
 	var sb strings.Builder
 	pr := a.ParseResult
 	sb.WriteString("\nAbuse Scanner Report:\n")
+
+	sb.WriteString("\nServer:\n")
+	sb.WriteString(fmt.Sprintf("%v\n", a.InsertedBy))
 
 	sb.WriteString("\nReporter:\n")
 	sb.WriteString(fmt.Sprintf("Name: %v\n", pr.Reporter.Name))

--- a/database/abusescanner.go
+++ b/database/abusescanner.go
@@ -16,9 +16,6 @@ import (
 )
 
 const (
-	// AbuseDatabaseName defines the name of the mongo database
-	AbuseDatabaseName = "abuse-scanner"
-
 	// AbuseStatusBlocked denotes the blocked status.
 	AbuseStatusBlocked = "BLOCKED"
 
@@ -27,6 +24,9 @@ const (
 
 	// AbuseDefaultTag is the tag used when there are no tags found in the email
 	AbuseDefaultTag = "abusive"
+
+	// DBAbuseScanner defines the name of the mongo database used by the scanner
+	DBAbuseScanner = "abuse-scanner"
 
 	// collEmails is the name of the collection that contains all email objects
 	collEmails = "emails"

--- a/database/abusescanner.go
+++ b/database/abusescanner.go
@@ -122,7 +122,7 @@ func (a AbuseEmail) String() string {
 	sb.WriteString("\nAbuse Scanner Report:\n")
 
 	sb.WriteString("\nServer:\n")
-	sb.WriteString(fmt.Sprintf("%v\n", a.InsertedBy))
+	sb.WriteString(fmt.Sprintf("Domain: %v\n", a.InsertedBy))
 
 	sb.WriteString("\nReporter:\n")
 	sb.WriteString(fmt.Sprintf("Name: %v\n", pr.Reporter.Name))

--- a/email/blocker.go
+++ b/email/blocker.go
@@ -26,12 +26,11 @@ type (
 	// Blocker is an object that will periodically scan the database for abuse
 	// reports that have not been blocked yet.
 	Blocker struct {
-		staticBlockerApiUrl     string
-		staticBlockerAuthHeader string
-		staticContext           context.Context
-		staticDatabase          *database.AbuseScannerDB
-		staticLogger            *logrus.Entry
-		staticWaitGroup         sync.WaitGroup
+		staticBlockerApiUrl string
+		staticContext       context.Context
+		staticDatabase      *database.AbuseScannerDB
+		staticLogger        *logrus.Entry
+		staticWaitGroup     sync.WaitGroup
 	}
 
 	// BlockPOST is the datastructure expected by the blocker API
@@ -43,13 +42,12 @@ type (
 )
 
 // NewBlocker creates a new blocker.
-func NewBlocker(ctx context.Context, blockerAuthHeader, blockerApiUrl string, database *database.AbuseScannerDB, logger *logrus.Logger) *Blocker {
+func NewBlocker(ctx context.Context, blockerApiUrl string, database *database.AbuseScannerDB, logger *logrus.Logger) *Blocker {
 	return &Blocker{
-		staticBlockerAuthHeader: blockerAuthHeader,
-		staticBlockerApiUrl:     blockerApiUrl,
-		staticContext:           ctx,
-		staticDatabase:          database,
-		staticLogger:            logger.WithField("module", "Blocker"),
+		staticBlockerApiUrl: blockerApiUrl,
+		staticContext:       ctx,
+		staticDatabase:      database,
+		staticLogger:        logger.WithField("module", "Blocker"),
 	}
 }
 
@@ -225,11 +223,6 @@ func (b *Blocker) buildBlockRequest(skylink string, report database.AbuseReport)
 	}
 
 	// add the headers
-	//
-	// TODO: we don't even need the auth header here seeing as we removed
-	// authentication from that route in the blocker API, I left it here anyway
-	// as we might bring that back in the future
-	// req.Header.Set("Authorization", b.staticBlockerAuthHeader)
 	req.Header.Set("User-Agent", "Sia-Agent")
 	return req, nil
 }

--- a/email/blocker.go
+++ b/email/blocker.go
@@ -160,6 +160,7 @@ func (b *Blocker) blockEmail(email database.AbuseEmail) error {
 		bson.D{
 			{"$set", bson.D{
 				{"blocked", true},
+				{"blocked_at", time.Now().UTC()},
 				{"block_result", result},
 			}},
 		},

--- a/email/blocker.go
+++ b/email/blocker.go
@@ -101,11 +101,11 @@ func (b *Blocker) threadedBlockMessages() {
 			// log unblocked messages count
 			numUnblocked := len(toBlock)
 			if numUnblocked == 0 {
-				logger.Debugf("Found %v unblocked messages\n", numUnblocked)
+				logger.Debugf("Found %v unblocked messages", numUnblocked)
 				return
 			}
 
-			logger.Infof("Found %v unblocked messages\n", numUnblocked)
+			logger.Infof("Found %v unblocked messages", numUnblocked)
 
 			// loop all emails and block the skylinks they contain
 			for _, email := range toBlock {

--- a/email/blocker.go
+++ b/email/blocker.go
@@ -127,13 +127,13 @@ func (b *Blocker) threadedBlockMessages() {
 
 // blockEmail will block the skylinks that are contained in the parse result of
 // the given email.
-func (b *Blocker) blockEmail(email database.AbuseEmail) error {
+func (b *Blocker) blockEmail(email database.AbuseEmail) (err error) {
 	// convenience variables
 	abuseDB := b.staticDatabase
 
 	// acquire the lock
 	lock := abuseDB.NewLock(email.UID)
-	err := lock.Lock()
+	err = lock.Lock()
 	if err != nil {
 		return errors.AddContext(err, "could not acquire lock")
 	}

--- a/email/blocker.go
+++ b/email/blocker.go
@@ -193,6 +193,12 @@ func (b *Blocker) blockReport(report database.AbuseReport) ([]string, error) {
 			if err != nil {
 				return fmt.Sprintf("failed to execute request, err: %v", err.Error())
 			}
+			defer func() {
+				err = resp.Body.Close()
+				if err != nil {
+					b.staticLogger.Errorf("failed to close response body, err: %v", err)
+				}
+			}()
 
 			// handle the response
 			switch resp.StatusCode {
@@ -203,7 +209,6 @@ func (b *Blocker) blockReport(report database.AbuseReport) ([]string, error) {
 				if err != nil {
 					return fmt.Sprintf("failed to read response body, err: %v", err.Error())
 				}
-				resp.Body.Close()
 				return fmt.Sprintf("failed to block skylink, status %v response: %v", resp.Status, string(respBody))
 			}
 		}()

--- a/email/blocker.go
+++ b/email/blocker.go
@@ -110,7 +110,7 @@ func (b *Blocker) blockMessages() {
 	// fetch all unblocked emails
 	toBlock, err := abuseDB.FindUnblocked()
 	if err != nil {
-		logger.Errorf("Failed fetching unparsed emails, error %v", err)
+		logger.Errorf("Failed fetching unblocked emails, error %v", err)
 		return
 	}
 

--- a/email/client.go
+++ b/email/client.go
@@ -8,6 +8,7 @@ import (
 var (
 	// ErrTooManyConnections is returned by the IMAP server if the connection
 	// can't be established because there are too many simultaneous connections.
+	// By default, Gmail's IMAP server uses a limit of only 15 connections.
 	ErrTooManyConnections = errors.New("Too many simultaneous connections")
 )
 

--- a/email/client.go
+++ b/email/client.go
@@ -2,18 +2,34 @@ package email
 
 import (
 	"github.com/emersion/go-imap/client"
+	"gitlab.com/NebulousLabs/errors"
+)
+
+var (
+	// ErrTooManyConnections is returned by the IMAP server if the connection
+	// can't be established because there are too many simultaneous connections.
+	ErrTooManyConnections = errors.New("Too many simultaneous connections")
+)
+
+type (
+	// Credentials contains all the necessary information to create a new client
+	Credentials struct {
+		Address  string
+		Username string
+		Password string
+	}
 )
 
 // NewClient returns an authenticated email client
-func NewClient(mailServer, username, password string) (*client.Client, error) {
+func NewClient(credentials Credentials) (*client.Client, error) {
 	// connect to server
-	c, err := client.DialTLS(mailServer, nil)
+	c, err := client.DialTLS(credentials.Address, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	// authenticate
-	if err := c.Login(username, password); err != nil {
+	if err := c.Login(credentials.Username, credentials.Password); err != nil {
 		return nil, err
 	}
 

--- a/email/fetcher.go
+++ b/email/fetcher.go
@@ -79,6 +79,9 @@ func (f *Fetcher) threadedFetchMessages() {
 	// create a ticker
 	ticker := time.NewTicker(fetchFrequency)
 
+	// log information about the mailbox we're fetching from
+	logger.Infof("Fetching messages for '%v' from mailbox '%v'", f.staticEmailCredentials.Username, f.staticMailbox)
+
 	// start the loop
 	for {
 		logger.Debugln("Triggered")

--- a/email/fetcher.go
+++ b/email/fetcher.go
@@ -179,7 +179,7 @@ func (f *Fetcher) getMessageIds(email *client.Client) ([]uint32, error) {
 	go func() {
 		err = email.Fetch(seqset, []imap.FetchItem{imap.FetchUid}, messageChan)
 		if err != nil {
-			logger.Errorf("Failed listing messages, error: %v\n", err)
+			logger.Errorf("Failed listing messages, error: %v", err)
 		}
 	}()
 
@@ -241,7 +241,7 @@ func (f *Fetcher) fetchMessages(client *client.Client, mailbox *imap.MailboxStat
 			logger.Debugf("skip message from abuse scanner (expected)")
 			err := f.persistSkipMessage(mailbox, msg)
 			if err != nil {
-				logger.Errorf("Failed to persist skip message, error: %v\n", err)
+				logger.Errorf("Failed to persist skip message, error: %v", err)
 			}
 			continue
 		}
@@ -253,7 +253,7 @@ func (f *Fetcher) fetchMessages(client *client.Client, mailbox *imap.MailboxStat
 			logger.Debugf("skip message due to not having a body (expected)")
 			err := f.persistSkipMessage(mailbox, msg)
 			if err != nil {
-				logger.Errorf("Failed to persist skip message, error: %v\n", err)
+				logger.Errorf("Failed to persist skip message, error: %v", err)
 			}
 			continue
 		}
@@ -261,7 +261,7 @@ func (f *Fetcher) fetchMessages(client *client.Client, mailbox *imap.MailboxStat
 		toUnsee.AddNum(msg.Uid)
 		err := f.persistMessage(mailbox, msg, section)
 		if err != nil {
-			logger.Errorf("Failed to persist %v, error: %v\n", msg.Uid, err)
+			logger.Errorf("Failed to persist %v, error: %v", msg.Uid, err)
 		}
 	}
 
@@ -269,7 +269,7 @@ func (f *Fetcher) fetchMessages(client *client.Client, mailbox *imap.MailboxStat
 	flags := []interface{}{imap.SeenFlag}
 	err = client.UidStore(toUnsee, "-FLAGS.SILENT", flags, nil)
 	if err != nil && !strings.Contains(err.Error(), "Could not parse command") {
-		logger.Debugf("Failed to unsee messages, error: %v\n", err)
+		logger.Debugf("Failed to unsee messages, error: %v", err)
 	} else {
 		logger.Debugln("Successfully unseen messages")
 	}

--- a/email/fetcher.go
+++ b/email/fetcher.go
@@ -31,18 +31,20 @@ type (
 		staticEmailCredentials Credentials
 		staticLogger           *logrus.Entry
 		staticMailbox          string
+		staticServerDomain     string
 		staticWaitGroup        sync.WaitGroup
 	}
 )
 
 // NewFetcher creates a new fetcher.
-func NewFetcher(ctx context.Context, database *database.AbuseScannerDB, emailCredentials Credentials, mailbox string, logger *logrus.Logger) *Fetcher {
+func NewFetcher(ctx context.Context, database *database.AbuseScannerDB, emailCredentials Credentials, mailbox, serverDomain string, logger *logrus.Logger) *Fetcher {
 	return &Fetcher{
 		staticContext:          ctx,
 		staticDatabase:         database,
 		staticEmailCredentials: emailCredentials,
 		staticLogger:           logger.WithField("module", "Fetcher"),
 		staticMailbox:          mailbox,
+		staticServerDomain:     serverDomain,
 	}
 }
 
@@ -316,6 +318,7 @@ func (f *Fetcher) persistMessage(mailbox *imap.MailboxStatus, msg *imap.Message,
 		Blocked:   false,
 		Finalized: false,
 
+		InsertedBy: f.staticServerDomain,
 		InsertedAt: time.Now().UTC(),
 	}
 

--- a/email/finalizer.go
+++ b/email/finalizer.go
@@ -131,6 +131,7 @@ func (f *Finalizer) finalizeEmail(client *client.Client, email database.AbuseEma
 	err = abuseDB.UpdateNoLock(email, bson.D{
 		{"$set", bson.D{
 			{"finalized", true},
+			{"finalized_at", time.Now().UTC()},
 		}},
 	})
 	if err != nil {

--- a/email/finalizer.go
+++ b/email/finalizer.go
@@ -33,13 +33,12 @@ type (
 		staticLogger           *logrus.Entry
 		staticMailbox          string
 		staticMailaddress      string
-		staticServerDomain     string
 		staticWaitGroup        sync.WaitGroup
 	}
 )
 
 // NewFinalizer creates a new finalizer.
-func NewFinalizer(ctx context.Context, database *database.AbuseScannerDB, emailCredentials Credentials, mailaddress, mailbox, serverDomain string, logger *logrus.Logger) *Finalizer {
+func NewFinalizer(ctx context.Context, database *database.AbuseScannerDB, emailCredentials Credentials, mailaddress, mailbox string, logger *logrus.Logger) *Finalizer {
 	return &Finalizer{
 		staticContext:          ctx,
 		staticDatabase:         database,
@@ -47,7 +46,6 @@ func NewFinalizer(ctx context.Context, database *database.AbuseScannerDB, emailC
 		staticLogger:           logger.WithField("module", "Finalizer"),
 		staticMailaddress:      mailaddress,
 		staticMailbox:          mailbox,
-		staticServerDomain:     serverDomain,
 	}
 }
 
@@ -121,8 +119,6 @@ func (f *Finalizer) finalizeEmail(client *client.Client, email database.AbuseEma
 	msg += fmt.Sprintf("To:%s\n", f.staticMailaddress)
 	msg += ""
 	msg += email.String()
-	msg += ""
-	msg += fmt.Sprintf("Handled by: %s\n", f.staticServerDomain)
 	reader := strings.NewReader(msg)
 
 	// append an email with the abuse report result

--- a/email/finalizer.go
+++ b/email/finalizer.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// finalizeFrequency defines the frequency with which we finalize reports
-	finalizeFrequency = 20 * time.Second
+	finalizeFrequency = 30 * time.Second
 
 	// scannerEmailAddress is the from email we use when sending abuse reports
 	scannerEmailAddress = "abuse-scanner@siasky.net"
@@ -159,7 +159,10 @@ func (f *Finalizer) threadedFinalizeMessages() {
 		func() {
 			// create an email client
 			client, err := NewClient(f.staticEmailCredentials)
-			if err != nil {
+			if err != nil && strings.Contains(err.Error(), ErrTooManyConnections.Error()) {
+				logger.Debugf("Skipped due to Too Many Connections (expected)")
+				return
+			} else if err != nil {
 				logger.Errorf("Failed to initialize email client, err %v", err)
 				return
 			}

--- a/email/finalizer.go
+++ b/email/finalizer.go
@@ -80,7 +80,7 @@ func (f *Finalizer) Stop() error {
 func (f *Finalizer) finalizeEmail(client *client.Client, email database.AbuseEmail) error {
 	// sanity check every skylink has a blocked status
 	if len(email.BlockResult) != len(email.ParseResult.Skylinks) {
-		return fmt.Errorf("blockresult vs parseresult length, %v != %v, email with id %v\n", len(email.BlockResult), len(email.ParseResult.Skylinks), email.ID.String())
+		return fmt.Errorf("blockresult vs parseresult length, %v != %v, email with id %v", len(email.BlockResult), len(email.ParseResult.Skylinks), email.ID.String())
 	}
 
 	// convenience variables
@@ -181,11 +181,11 @@ func (f *Finalizer) threadedFinalizeMessages() {
 			// log unfinalized message count
 			numUnfinalized := len(toFinalize)
 			if numUnfinalized == 0 {
-				logger.Debugf("Found %v unfinalized messages\n", numUnfinalized)
+				logger.Debugf("Found %v unfinalized messages", numUnfinalized)
 				return
 			}
 
-			logger.Infof("Found %v unfinalized messages\n", numUnfinalized)
+			logger.Infof("Found %v unfinalized messages", numUnfinalized)
 
 			// loop all emails and parse them
 			for _, email := range toFinalize {

--- a/email/finalizer.go
+++ b/email/finalizer.go
@@ -172,7 +172,7 @@ func (f *Finalizer) finalizeMessages() {
 	// fetch all unfinalized emails
 	toFinalize, err := abuseDB.FindUnfinalized()
 	if err != nil {
-		logger.Errorf("Failed fetching unparsed emails, error %v", err)
+		logger.Errorf("Failed fetching unfinalized emails, error %v", err)
 		return
 	}
 

--- a/email/finalizer.go
+++ b/email/finalizer.go
@@ -29,22 +29,22 @@ type (
 	Finalizer struct {
 		staticContext          context.Context
 		staticDatabase         *database.AbuseScannerDB
+		staticEmailAddress     string
 		staticEmailCredentials Credentials
 		staticLogger           *logrus.Entry
 		staticMailbox          string
-		staticMailaddress      string
 		staticWaitGroup        sync.WaitGroup
 	}
 )
 
 // NewFinalizer creates a new finalizer.
-func NewFinalizer(ctx context.Context, database *database.AbuseScannerDB, emailCredentials Credentials, mailaddress, mailbox string, logger *logrus.Logger) *Finalizer {
+func NewFinalizer(ctx context.Context, database *database.AbuseScannerDB, emailCredentials Credentials, emailAddress, mailbox string, logger *logrus.Logger) *Finalizer {
 	return &Finalizer{
 		staticContext:          ctx,
 		staticDatabase:         database,
+		staticEmailAddress:     emailAddress,
 		staticEmailCredentials: emailCredentials,
 		staticLogger:           logger.WithField("module", "Finalizer"),
-		staticMailaddress:      mailaddress,
 		staticMailbox:          mailbox,
 	}
 }
@@ -117,7 +117,7 @@ func (f *Finalizer) finalizeEmail(client *client.Client, email database.AbuseEma
 	msg += fmt.Sprintf("References: %s\n", email.MessageID)
 	msg += fmt.Sprintf("In-Reply-To: %s\n", email.MessageID)
 	msg += fmt.Sprintf("From: SCANNED <%s>\n", scannerEmailAddress)
-	msg += fmt.Sprintf("To:%s\n", f.staticMailaddress)
+	msg += fmt.Sprintf("To:%s\n", f.staticEmailAddress)
 	msg += ""
 	msg += email.String()
 	reader := strings.NewReader(msg)

--- a/email/parser.go
+++ b/email/parser.go
@@ -217,11 +217,11 @@ func (p *Parser) threadedParseMessages() {
 			// log unparsed messages count
 			numUnparsed := len(toParse)
 			if numUnparsed == 0 {
-				logger.Debugf("Found %v unparsed messages\n", numUnparsed)
+				logger.Debugf("Found %v unparsed messages", numUnparsed)
 				return
 			}
 
-			logger.Infof("Found %v unparsed messages\n", numUnparsed)
+			logger.Infof("Found %v unparsed messages", numUnparsed)
 
 			// loop all emails and parse them
 			for _, email := range toParse {

--- a/email/parser.go
+++ b/email/parser.go
@@ -149,13 +149,13 @@ func (p *Parser) buildAbuseReport(email database.AbuseEmail) (database.AbuseRepo
 // parseEmail will parse the body of the given email into a list of abuse
 // reports. Every report contains a unique skylink with extra metadata and can
 // be used to block abusive skylinks.
-func (p *Parser) parseEmail(email database.AbuseEmail) error {
+func (p *Parser) parseEmail(email database.AbuseEmail) (err error) {
 	// convenience variables
 	abuseDB := p.staticDatabase
 
 	// acquire a lock on the email
 	lock := abuseDB.NewLock(email.UID)
-	err := lock.Lock()
+	err = lock.Lock()
 	if err != nil {
 		return errors.AddContext(err, "could not acquire lock")
 	}
@@ -170,7 +170,8 @@ func (p *Parser) parseEmail(email database.AbuseEmail) error {
 	}()
 
 	// parse the email body into a report
-	report, err := p.buildAbuseReport(email)
+	var report database.AbuseReport
+	report, err = p.buildAbuseReport(email)
 	if err != nil {
 		return errors.AddContext(err, "could not parse email body")
 	}

--- a/email/parser_test.go
+++ b/email/parser_test.go
@@ -1,0 +1,222 @@
+package email
+
+import (
+	"abuse-scanner/database"
+	"context"
+	"io/ioutil"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gitlab.com/SkynetLabs/skyd/skymodules"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+var (
+	// exampleBody is an example body of an abuse email as it gets reported by a
+	// provider, the Skylinks in the examples are scrambled and not real
+	exampleBody = []byte(`
+	Hello,
+
+	Please be informed that we have located another phishing content located at the following URLs:
+
+	hxxps:// siasky [.] net/GAEE7l0IkIVcVEHDgRCcNkRYS8keZKr9v_ffxf9_614m6g
+	hxxps:// siasky [.] net/nAA_hbtNaOYyR2WrM9UNIc5jRu4WfGy5QK_iTGosDgLmSA#info@jwmarine [.] com [.] au
+	hxxps:// siasky [.] net/CADEnmNNR6arnyDSH60MlGjQK5O3Sv-ecK1PGt3MNmQUhA#apg@franklinbank [.] com
+	hxxps:// siasky [.] net/GABJJhT8AlfNh-XS-6YVH8en7O-t377ej9XS2eclnv2yFg
+
+	As a reminder, phishing is expressly prohibited by our Universal Terms of Service Agreement, paragraph 7. "Acceptable Use Policy (AUP)"
+	`)
+)
+
+// TestParser is a collection of unit tests that probe the functionality of
+// various methods related to parsing abuse emails.
+func TestParser(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	t.Run("BuildAbuseReport", testBuildAbuseReport)
+	t.Run("ExtractSkylinks", testExtractSkylinks)
+	t.Run("ExtractTags", testExtractTags)
+}
+
+// testExtractSkylinks is a unit test that verifies the behaviour of the
+// 'extractSkylinks' helper function
+func testExtractSkylinks(t *testing.T) {
+	t.Parallel()
+
+	// base case
+	skylinks := extractSkylinks(nil)
+	if len(skylinks) != 0 {
+		t.Fatalf("unexpected amount of skylinks found, %v != 0", len(skylinks))
+	}
+
+	// extract skylinks
+	skylinks = extractSkylinks(exampleBody)
+	if len(skylinks) != 4 {
+		t.Fatalf("unexpected amount of skylinks found, %v != 4", len(skylinks))
+	}
+
+	// assert we have extracted the correct skylinks
+	sort.Strings(skylinks)
+	if skylinks[0] != "CADEnmNNR6arnyDSH60MlGjQK5O3Sv-ecK1PGt3MNmQUhA" ||
+		skylinks[1] != "GABJJhT8AlfNh-XS-6YVH8en7O-t377ej9XS2eclnv2yFg" || skylinks[2] != "GAEE7l0IkIVcVEHDgRCcNkRYS8keZKr9v_ffxf9_614m6g" || skylinks[3] != "nAA_hbtNaOYyR2WrM9UNIc5jRu4WfGy5QK_iTGosDgLmSA" {
+		t.Fatal("unexpected skylinks", skylinks)
+	}
+
+	// use a made up email body that contains base32 skylinks
+	skylinks = extractSkylinks([]byte(`
+	Hello,
+
+	Please be informed that we have located another phishing content located at the following URLs:
+
+	hxxps:// 7g01n1fmusamd3k4c5l7ahb39356rfhfs92e9mjshj1vq93vk891m2o [.] siasky [.] net
+	`))
+	if len(skylinks) != 1 {
+		t.Fatalf("unexpected amount of skylinks found, %v != 1", len(skylinks))
+	}
+
+	// NOTE: it will have loaded the base32 encoded version Skylink and output
+	// its base64 encoded version
+	var sl skymodules.Skylink
+	if err := sl.LoadString("7g01n1fmusamd3k4c5l7ahb39356rfhfs92e9mjshj1vq93vk891m2o"); err != nil {
+		t.Fatal(err)
+	}
+	if skylinks[0] != sl.String() {
+		t.Fatal("unexpected skylinks", skylinks)
+	}
+}
+
+// testExtractTags is a unit test that verifies the behaviour of the
+// 'extractTags' helper function
+func testExtractTags(t *testing.T) {
+	t.Parallel()
+
+	// base case, assert the abusive tags is returned of no others were found
+	tags := extractTags(nil)
+	if len(tags) != 1 {
+		t.Fatalf("unexpected amount of tags found, %v != 1", len(tags))
+	}
+	if tags[0] != database.AbuseDefaultTag {
+		t.Fatal("unexpected tag", tags[0])
+	}
+
+	// use a made up email body that contains all tags
+	exampleBody := []byte(`
+	This is an example of an email body that might contain phishing links, but could also contain malware or even skylinks that are infringing on copyright. In the worst cases it might contain skylinks that link to terrorist content or even child pornographic material, also known as csam.
+	`)
+
+	// extract the tags and assert we found all of them
+	tags = extractTags(exampleBody)
+	if len(tags) != 5 {
+		t.Fatalf("unexpected amount of tags found, %v != 5", len(tags))
+	}
+
+	// assert we have extracted the correct tags
+	sort.Strings(tags)
+	if tags[0] != "copyright" || tags[1] != "csam" || tags[2] != "malware" || tags[3] != "phishing" || tags[4] != "terrorism" {
+		t.Fatal("unexpected tags", tags)
+	}
+}
+
+// testBuildAbuseReport is a unit test that verifies the functionality of the
+// 'buildAbuseReport' method on the Parser.
+func testBuildAbuseReport(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	// create discard logger
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+
+	// create test database
+	db, err := newTestDatabase(ctx, "testBuildAbuseReport", logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// purge the database
+	err = db.Purge(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a parser
+	parser := NewParser(ctx, db, "somesponsor", logger)
+
+	// create an abuse email
+	email := database.AbuseEmail{
+		ID:        primitive.NewObjectID(),
+		UID:       "INBOX-1",
+		UIDRaw:    1,
+		Body:      exampleBody,
+		From:      "someone@gmail.com",
+		Subject:   "Abuse Subject",
+		MessageID: "<msg_uid>@gmail.com",
+
+		Parsed:    false,
+		Blocked:   false,
+		Finalized: false,
+
+		InsertedBy: "dev.siasky.net",
+		InsertedAt: time.Now().UTC(),
+	}
+
+	// insert the email
+	err = db.InsertOne(email)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// parse the email
+	err = parser.parseEmail(email)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// fetch the email
+	updated, err := db.FindOne(email.UID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert various fields on the email
+	if !updated.Parsed {
+		t.Fatal("expected the email to be parsed")
+	}
+	if updated.ParsedAt == (time.Time{}) {
+		t.Fatal("expected 'parsedAt' to be set")
+	}
+	if updated.Finalized {
+		t.Fatal("expected the email to not be finalized")
+	}
+
+	// assert the parse result, note that we don't deep equal the parse result,
+	// since we use the example email body we can rest assured it's correct
+	// since the unit tests cover that as well
+	pr := updated.ParseResult
+	if len(pr.Skylinks) != 4 {
+		t.Fatal("unexpected amount of skylinks", pr.Skylinks)
+	}
+	if len(pr.Tags) != 1 {
+		t.Fatal("unexpected amount of tags", pr.Tags)
+	}
+	if pr.Sponsor != "somesponsor" {
+		t.Fatal("unexpected sponsor", pr.Sponsor)
+	}
+	if pr.Reporter.Email != "someone@gmail.com" {
+		t.Fatal("unexpected reporter", pr.Reporter.Email)
+	}
+}
+
+// newTestDatabase returns a test database with given name.
+func newTestDatabase(ctx context.Context, dbName string, logger *logrus.Logger) (*database.AbuseScannerDB, error) {
+	return database.NewAbuseScannerDB(ctx, "", "mongodb://localhost:37017", dbName, options.Credential{
+		Username: "admin",
+		Password: "aO4tV5tC1oU3oQ7u",
+	}, logger)
+}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,9 @@ require (
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f // indirect
 	github.com/dchest/threefish v0.0.0-20120919164726-3ecf4c494abf // indirect
+	github.com/emersion/go-message v0.15.0 // indirect
 	github.com/emersion/go-sasl v0.0.0-20211008083017-0b9dcfb154ac // indirect
+	github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -45,8 +45,8 @@ require (
 	gitlab.com/NebulousLabs/threadgroup v0.0.0-20200608151952-38921fbef213 // indirect
 	go.sia.tech/siad v1.5.7 // indirect
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b // indirect
-	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -115,10 +115,12 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/emersion/go-imap v1.2.0 h1:lyUQ3+EVM21/qbWE/4Ya5UG9r5+usDxlg4yfp3TgHFA=
 github.com/emersion/go-imap v1.2.0/go.mod h1:Qlx1FSx2FTxjnjWpIlVNEuX+ylerZQNFE5NsmKFSejY=
+github.com/emersion/go-message v0.15.0 h1:urgKGqt2JAc9NFJcgncQcohHdiYb803YTH9OQwHBHIY=
 github.com/emersion/go-message v0.15.0/go.mod h1:wQUEfE+38+7EW8p8aZ96ptg6bAb1iwdgej19uXASlE4=
 github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
 github.com/emersion/go-sasl v0.0.0-20211008083017-0b9dcfb154ac h1:tn/OQ2PmwQ0XFVgAHfjlLyqMewry25Rz7jWnVoh4Ggs=
 github.com/emersion/go-sasl v0.0.0-20211008083017-0b9dcfb154ac/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
+github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594 h1:IbFBtwoTQyw0fIM5xv1HF+Y+3ZijDR839WMulgxCcUY=
 github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594/go.mod h1:aqO8z8wPrjkscevZJFVE1wXJrLpC5LtJG7fqLOsPb2U=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go.sum
+++ b/go.sum
@@ -646,6 +646,8 @@ golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63 h1:iocB37TsdFuN6IBRZ+ry36wrkoV51/tl5vOWqkcPGvY=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -744,6 +746,8 @@ golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486 h1:5hpz5aRr+W1erYCL5JRhSUBJRph7l9XkNveoExlrKYk=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210421210424-b80969c67360/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	// create a new mail fetcher, it downloads the emails
 	logger.Info("Initializing email fetcher...")
-	fetcher := email.NewFetcher(ctx, db, emailCredentials, abuseMailbox, logger)
+	fetcher := email.NewFetcher(ctx, db, emailCredentials, abuseMailbox, serverDomain, logger)
 	err = fetcher.Start()
 	if err != nil {
 		log.Fatal("Failed to start the email fetcher, err: ", err)
@@ -106,7 +106,7 @@ func main() {
 	// when the abuse scanner has replied with a report of all the skylinks that
 	// have been found and blocked.
 	logger.Info("Initializing finalizer...")
-	finalizer := email.NewFinalizer(ctx, db, emailCredentials, abuseMailaddress, abuseMailbox, serverDomain, logger)
+	finalizer := email.NewFinalizer(ctx, db, emailCredentials, abuseMailaddress, abuseMailbox, logger)
 	err = finalizer.Start()
 	if err != nil {
 		log.Fatal("Failed to start the email finalizer, err: ", err)

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	// create a database instance
-	db, err := database.NewAbuseScannerDB(ctx, serverDomain, mongoUri, mongoCreds, logger)
+	db, err := database.NewAbuseScannerDB(ctx, serverDomain, mongoUri, database.AbuseDatabaseName, mongoCreds, logger)
 	if err != nil {
 		log.Fatalf("Failed to initialize database client, err: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -77,10 +77,10 @@ func main() {
 	// create a new mail fetcher, it downloads the emails
 	logger.Info("Initializing email fetcher...")
 	fetcher := email.NewFetcher(ctx, db, emailCredentials, abuseMailbox, serverDomain, logger)
-	// err = fetcher.Start()
-	// if err != nil {
-	// 	log.Fatal("Failed to start the email fetcher, err: ", err)
-	// }
+	err = fetcher.Start()
+	if err != nil {
+		log.Fatal("Failed to start the email fetcher, err: ", err)
+	}
 
 	// create a new mail parser, it parses any email that's not parsed yet for
 	// abuse skylinks and a set of abuse tag
@@ -96,10 +96,10 @@ func main() {
 	logger.Info("Initializing blocker...")
 	blockerApiUrl := fmt.Sprintf("http://%s:%s", blockerHost, blockerPort)
 	blocker := email.NewBlocker(ctx, blockerApiUrl, db, logger)
-	// err = blocker.Start()
-	// if err != nil {
-	// 	log.Fatal("Failed to start the blocker, err: ", err)
-	// }
+	err = blocker.Start()
+	if err != nil {
+		log.Fatal("Failed to start the blocker, err: ", err)
+	}
 
 	// create a new finalizer, it finalizes the abuse report for any emails
 	// which are parsed, blocked, but not yet finalized. An email is finalized
@@ -107,10 +107,10 @@ func main() {
 	// have been found and blocked.
 	logger.Info("Initializing finalizer...")
 	finalizer := email.NewFinalizer(ctx, db, emailCredentials, abuseMailaddress, abuseMailbox, logger)
-	// err = finalizer.Start()
-	// if err != nil {
-	// 	log.Fatal("Failed to start the email finalizer, err: ", err)
-	// }
+	err = finalizer.Start()
+	if err != nil {
+		log.Fatal("Failed to start the email finalizer, err: ", err)
+	}
 
 	// catch exit signals
 	exitSignal := make(chan os.Signal, 1)

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	// create a database instance
-	db, err := database.NewAbuseScannerDB(ctx, serverDomain, mongoUri, database.AbuseDatabaseName, mongoCreds, logger)
+	db, err := database.NewAbuseScannerDB(ctx, serverDomain, mongoUri, database.DBAbuseScanner, mongoCreds, logger)
 	if err != nil {
 		log.Fatalf("Failed to initialize database client, err: %v", err)
 	}
@@ -77,10 +77,10 @@ func main() {
 	// create a new mail fetcher, it downloads the emails
 	logger.Info("Initializing email fetcher...")
 	fetcher := email.NewFetcher(ctx, db, emailCredentials, abuseMailbox, serverDomain, logger)
-	err = fetcher.Start()
-	if err != nil {
-		log.Fatal("Failed to start the email fetcher, err: ", err)
-	}
+	// err = fetcher.Start()
+	// if err != nil {
+	// 	log.Fatal("Failed to start the email fetcher, err: ", err)
+	// }
 
 	// create a new mail parser, it parses any email that's not parsed yet for
 	// abuse skylinks and a set of abuse tag
@@ -96,10 +96,10 @@ func main() {
 	logger.Info("Initializing blocker...")
 	blockerApiUrl := fmt.Sprintf("http://%s:%s", blockerHost, blockerPort)
 	blocker := email.NewBlocker(ctx, blockerApiUrl, db, logger)
-	err = blocker.Start()
-	if err != nil {
-		log.Fatal("Failed to start the blocker, err: ", err)
-	}
+	// err = blocker.Start()
+	// if err != nil {
+	// 	log.Fatal("Failed to start the blocker, err: ", err)
+	// }
 
 	// create a new finalizer, it finalizes the abuse report for any emails
 	// which are parsed, blocked, but not yet finalized. An email is finalized
@@ -107,10 +107,10 @@ func main() {
 	// have been found and blocked.
 	logger.Info("Initializing finalizer...")
 	finalizer := email.NewFinalizer(ctx, db, emailCredentials, abuseMailaddress, abuseMailbox, logger)
-	err = finalizer.Start()
-	if err != nil {
-		log.Fatal("Failed to start the email finalizer, err: ", err)
-	}
+	// err = finalizer.Start()
+	// if err != nil {
+	// 	log.Fatal("Failed to start the email finalizer, err: ", err)
+	// }
 
 	// catch exit signals
 	exitSignal := make(chan os.Signal, 1)


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR fixes the following outstanding issues we've seen with the abuse scanner:

- ensure the container does not exit if it can't get a connection to the IMAP server straight away
- use short-lived connections to the IMAP server, the modules that need a connection try and get one when needed
- ignore "Too Many Connections" error, it is expected to happen and not an issue, we still debug log it
- get rid of the `ReconnectFn`, we don't need this any longer as we use more short-lived connections now
- improve email body parsing (using `go-message` library)
- skip empty mailboxes (reported by pcfreak30 - wrt: https://github.com/mscdex/node-imap/issues/608)
- add mention of the server to the response email so we know what server responded
- add HTML parsing for multi-parts encoded in 'text/html'
- limit the amount of bytes we read from the email to 8MiB
- make sure every module sets all fields (`blocked_at`, `parsed_at`, `finalized_at` were unset)
- remove all mention of `BLOCKER_AUTH_HEADER`
- add some testing, still needs some form of integration testing
- cleanup logging

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
N/A