### PR TITLE
Response Templates

### DIFF
--- a/database/abuseemail.go
+++ b/database/abuseemail.go
@@ -19,14 +19,14 @@ const (
 	// AbuseDefaultTag is the tag used when there are no tags found in the email
 	AbuseDefaultTag = "abusive"
 
-	// responseTemplateLegalNotice is a small notice we append to the response
-	// template that mentions we do not store any content on our servers
-	responseTemplateLegalNotice = `
+	// responseLegalNotice is a small notice we append to the automated response
+	// that mentions we do not store any content on our servers
+	responseLegalNotice = `
 Please note that no content is stored on our servers, but rather on a decentralised network of hosts. 
-Therefor we are not to be held accountible for any potential abusive content they might contain.
+Therefore we are not to be held accountable for any potential abusive content it might contain.
 We will however do everything in our power to block access from said content when it gets reported.
 		
-Thank you for your reporting.
+Thank you for your report.
 `
 )
 
@@ -91,7 +91,7 @@ func (a AbuseEmail) String() string {
 	sb.WriteString("\nSummary:\n")
 	if len(blocked) == 0 && len(unblocked) == 0 {
 		sb.WriteString("FAILURE - no skylinks found.\n")
-	} else if len(unblocked) == 0 {
+	} else if len(unblocked) != 0 {
 		sb.WriteString("FAILURE - not all skylinks blocked.\n")
 	} else {
 		sb.WriteString("SUCCESS - all skylinks blocked.\n")
@@ -108,13 +108,13 @@ func (a AbuseEmail) String() string {
 
 	// write response template
 	sb.WriteString("\nResponse Template:\n\n")
-	sb.WriteString(a.responseTemplate())
+	sb.WriteString(a.response())
 	return sb.String()
 }
 
-// responseTemplate is a small helper method that returns a response template
-// for this abuse email
-func (a AbuseEmail) responseTemplate() string {
+// response is a small helper method that returns an automated response for this
+// abuse email
+func (a AbuseEmail) response() string {
 	// sanity check
 	if !a.Parsed || !a.Blocked {
 		build.Critical("result should only be called when the email has been parsed and blocked")
@@ -133,7 +133,7 @@ we have processed your report but were unable to find any valid links.
 Please verify the link is not corrupted as we need it in order to prevent access to it from our portals.
 
 %s
-`, responseTemplateLegalNotice)
+`, responseLegalNotice)
 	}
 
 	// build the response template
@@ -154,7 +154,7 @@ Please verify the link is not corrupted as we need it in order to prevent access
 		}
 	}
 
-	sb.WriteString(responseTemplateLegalNotice)
+	sb.WriteString(responseLegalNotice)
 	return sb.String()
 }
 

--- a/database/abuseemail.go
+++ b/database/abuseemail.go
@@ -1,0 +1,180 @@
+package database
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.sia.tech/siad/build"
+)
+
+const (
+	// AbuseStatusBlocked denotes the blocked status.
+	AbuseStatusBlocked = "BLOCKED"
+
+	// AbuseStatusNotBlocked denotes the not blocked status.
+	AbuseStatusNotBlocked = "NOT BLOCKED"
+
+	// AbuseDefaultTag is the tag used when there are no tags found in the email
+	AbuseDefaultTag = "abusive"
+
+	// responseTemplateLegalNotice is a small notice we append to the response
+	// template that mentions we do not store any content on our servers
+	responseTemplateLegalNotice = `
+Please note that no content is stored on our servers, but rather on a decentralised network of hosts. 
+Therefor we are not to be held accountible for any potential abusive content they might contain.
+We will however do everything in our power to block access from said content when it gets reported.
+		
+Thank you for your reporting.
+`
+)
+
+type (
+	// AbuseEmail represent an object in the emails collection.
+	AbuseEmail struct {
+		// fields set by fetcher
+		ID        primitive.ObjectID `bson:"_id"`
+		UID       string             `bson:"email_uid"`
+		UIDRaw    uint32             `bson:"email_uid_raw"`
+		Body      []byte             `bson:"email_body"`
+		From      string             `bson:"email_from"`
+		Subject   string             `bson:"email_subject"`
+		MessageID string             `bson:"email_message_id"`
+
+		InsertedBy string    `bson:"inserted_by"`
+		InsertedAt time.Time `bson:"inserted_at"`
+
+		Skip bool `bson:"skip"`
+
+		// fields set by parser
+		ParsedAt    time.Time   `bson:"parsed_at"`
+		ParseResult AbuseReport `bson:"parse_result"`
+		Parsed      bool        `bson:"parsed"`
+
+		// fields set by blocker
+		BlockedAt   time.Time `bson:"blocked_at"`
+		BlockResult []string  `bson:"block_result"`
+		Blocked     bool      `bson:"blocked"`
+
+		// fields set by finalizer
+		Finalized   bool      `bson:"finalized"`
+		FinalizedAt time.Time `bson:"finalized_at"`
+	}
+
+	// AbuseReport contains all information about an abuse report.
+	AbuseReport struct {
+		Skylinks []string      `bson:"skylinks"`
+		Reporter AbuseReporter `bson:"reporter"`
+		Sponsor  string        `bson:"sponsor"`
+		Tags     []string      `bson:"tags"`
+	}
+
+	// AbuseReporter encapsulates some information about the reporter.
+	AbuseReporter struct {
+		Name         string `bson:"name"`
+		Email        string `bson:"email"`
+		OtherContact string `bson:"other_contact"`
+	}
+)
+
+// String returns a string representation of the abuse email
+func (a AbuseEmail) String() string {
+	// convenience variables
+	pr := a.ParseResult
+	blocked, unblocked := a.result()
+
+	var sb strings.Builder
+	sb.WriteString("\nAbuse Scanner Report:\n")
+
+	// write summary
+	sb.WriteString("\nSummary:\n")
+	if len(blocked) == 0 && len(unblocked) == 0 {
+		sb.WriteString("FAILURE - no skylinks found.\n")
+	} else if len(unblocked) == 0 {
+		sb.WriteString("FAILURE - not all skylinks blocked.\n")
+	} else {
+		sb.WriteString("SUCCESS - all skylinks blocked.\n")
+	}
+
+	// write server info
+	sb.WriteString("\nServer Info:\n")
+	sb.WriteString(fmt.Sprintf("Domain: %v\n", a.InsertedBy))
+
+	// write reporter info
+	sb.WriteString("\nReporter:\n")
+	sb.WriteString(fmt.Sprintf("Name: %v\n", pr.Reporter.Name))
+	sb.WriteString(fmt.Sprintf("Email: %v\n", pr.Reporter.Email))
+
+	// write response template
+	sb.WriteString("\nResponse Template:\n\n")
+	sb.WriteString(a.responseTemplate())
+	return sb.String()
+}
+
+// responseTemplate is a small helper method that returns a response template
+// for this abuse email
+func (a AbuseEmail) responseTemplate() string {
+	// sanity check
+	if !a.Parsed || !a.Blocked {
+		build.Critical("result should only be called when the email has been parsed and blocked")
+		return ""
+	}
+
+	// fetch which skylinks were blocked and which ones weren't
+	blocked, unblocked := a.result()
+
+	// if no skylinks were found, return another version of the template
+	if len(blocked) == 0 && len(unblocked) == 0 {
+		return fmt.Sprintf(`
+Hello,
+
+we have processed your report but were unable to find any valid links.
+Please verify the link is not corrupted as we need it in order to prevent access to it from our portals.
+
+%s
+`, responseTemplateLegalNotice)
+	}
+
+	// build the response template
+	var sb strings.Builder
+	sb.WriteString("Hello,\n\n")
+
+	if len(blocked) > 0 {
+		sb.WriteString(fmt.Sprintf("the following links were identified and blocked on all of our servers as of %v\n", a.BlockedAt.Format("Mon Jan _2 15:04:05 2006")))
+		for _, skylink := range blocked {
+			sb.WriteString(fmt.Sprintf("- %s\n", skylink))
+		}
+	}
+
+	if len(unblocked) > 0 {
+		sb.WriteString("\nthe following links could not be blocked:\n")
+		for _, skylink := range unblocked {
+			sb.WriteString(fmt.Sprintf("- %s\n", skylink))
+		}
+	}
+
+	sb.WriteString(responseTemplateLegalNotice)
+	return sb.String()
+}
+
+// result returns which skylinks were blocked and which we failed to block
+func (a AbuseEmail) result() ([]string, []string) {
+	// sanity check
+	if !a.Parsed || !a.Blocked {
+		build.Critical("result should only be called when the email has been parsed and blocked")
+		return nil, nil
+	}
+
+	// split the parse result in blocked and unblocked skylinks
+	var blocked []string
+	var unblocked []string
+	for i, skylink := range a.ParseResult.Skylinks {
+		if a.BlockResult[i] == AbuseStatusBlocked {
+			blocked = append(blocked, skylink)
+		} else {
+			unblocked = append(unblocked, skylink)
+		}
+	}
+	return blocked, unblocked
+}

--- a/database/abuseemail.go
+++ b/database/abuseemail.go
@@ -25,7 +25,7 @@ const (
 Please note that no content is stored on our servers, but rather on a decentralised network of hosts. 
 Therefore we are not to be held accountable for any potential abusive content it might contain.
 We will, however, do everything in our power to block access from said content when it gets reported.
-		
+
 Thank you for your report.
 `
 )
@@ -131,7 +131,6 @@ Hello,
 
 we have processed your report but were unable to find any valid links.
 Please verify the link is not corrupted as we need it in order to prevent access to it from our portals.
-
 %s
 `, responseLegalNotice)
 	}
@@ -141,14 +140,14 @@ Please verify the link is not corrupted as we need it in order to prevent access
 	sb.WriteString("Hello,\n\n")
 
 	if len(blocked) > 0 {
-		sb.WriteString(fmt.Sprintf("the following links were identified and blocked on all of our servers as of %v\n", a.BlockedAt.Format("Mon Jan _2 15:04:05 2006")))
+		sb.WriteString(fmt.Sprintf("the following links were identified and blocked on all of our servers as of %v\n\n", a.BlockedAt.Format("Mon Jan _2 15:04:05 2006")))
 		for _, skylink := range blocked {
 			sb.WriteString(fmt.Sprintf("- %s\n", skylink))
 		}
 	}
 
 	if len(unblocked) > 0 {
-		sb.WriteString("\nthe following links could not be blocked:\n")
+		sb.WriteString("\nthe following links could not be blocked:\n\n")
 		for _, skylink := range unblocked {
 			sb.WriteString(fmt.Sprintf("- %s\n", skylink))
 		}

--- a/database/abuseemail.go
+++ b/database/abuseemail.go
@@ -24,7 +24,7 @@ const (
 	responseLegalNotice = `
 Please note that no content is stored on our servers, but rather on a decentralised network of hosts. 
 Therefore we are not to be held accountable for any potential abusive content it might contain.
-We will however do everything in our power to block access from said content when it gets reported.
+We will, however, do everything in our power to block access from said content when it gets reported.
 		
 Thank you for your report.
 `

--- a/database/abuseemail_test.go
+++ b/database/abuseemail_test.go
@@ -1,9 +1,12 @@
 package database
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/andreyvit/diff"
 )
 
 // TestAbuseEmail is a collection of unit tests around the abuse email object.
@@ -32,12 +35,13 @@ func TestAbuseEmail(t *testing.T) {
 // String method on the abuse email.
 func testString(t *testing.T) {
 	// draft a dummy abuse email
+	blockedAt := time.Now()
 	email := AbuseEmail{
 		InsertedBy: "some-server.skynetlabs.com",
 		InsertedAt: time.Now(),
 
 		Blocked:   true,
-		BlockedAt: time.Now(),
+		BlockedAt: blockedAt,
 
 		Parsed:   true,
 		ParsedAt: time.Now(),
@@ -79,18 +83,55 @@ func testString(t *testing.T) {
 	if !hasString("SUCCESS - all skylinks blocked") {
 		t.Fatal("unexpected", email.String())
 	}
+
+	// assert the whole abuse report for good measure
+	expected := fmt.Sprintf(`
+Abuse Scanner Report:
+
+Summary:
+SUCCESS - all skylinks blocked.
+
+Server Info:
+Domain: some-server.skynetlabs.com
+
+Reporter:
+Name: Skynetlabs Dev Team
+Email: devs@skynetlabs.com
+
+Response Template:
+
+Hello,
+
+the following links were identified and blocked on all of our servers as of %v
+
+- BBB6rPvqSR8Mcp0ulwFvFHSYvCZsnsizCvDPxac8HiThjQ
+- EAC6rPvqSR8Mcp0ulwFvFHSYvCZsnsizCvDPxac8HiThjQ
+
+Please note that no content is stored on our servers, but rather on a decentralised network of hosts. 
+Therefore we are not to be held accountable for any potential abusive content it might contain.
+We will, however, do everything in our power to block access from said content when it gets reported.
+
+Thank you for your report.
+`, blockedAt.Format("Mon Jan _2 15:04:05 2006"))
+
+	// assert it's identical
+	actual := email.String()
+	if actual != expected {
+		t.Fatal(diff.LineDiff(expected, actual))
+	}
 }
 
 // testTemplate verifies the implementation of the response template method on
 // the abuse email
 func testTemplate(t *testing.T) {
 	// draft a dummy abuse email
+	blockedAt := time.Now().UTC()
 	email := AbuseEmail{
 		InsertedBy: "some-server.skynetlabs.com",
 		InsertedAt: time.Now(),
 
 		Blocked:   true,
-		BlockedAt: time.Now(),
+		BlockedAt: blockedAt,
 
 		Parsed:   true,
 		ParsedAt: time.Now(),
@@ -106,20 +147,25 @@ func testTemplate(t *testing.T) {
 		BlockResult: nil,
 	}
 
-	// small helper function that checks whether the given string is part of the
-	// abuse email's response template
-	hasString := func(s string) bool {
-		return strings.Contains(email.response(), s)
-	}
+	// assert the abuse report looks as we expected it to, we use full string
+	// comparison to ensure it's absolutely the way we want it
+	expected := `
+Hello,
 
-	// check whether it returns the appropriate template
-	if !hasString("were unable to find any valid links") {
-		t.Fatal("unexpected response", email.String())
-	}
+we have processed your report but were unable to find any valid links.
+Please verify the link is not corrupted as we need it in order to prevent access to it from our portals.
 
-	// assert the legal notice is set
-	if !hasString("no content is stored on our servers") {
-		t.Fatal("unexpected response", email.String())
+Please note that no content is stored on our servers, but rather on a decentralised network of hosts. 
+Therefore we are not to be held accountable for any potential abusive content it might contain.
+We will, however, do everything in our power to block access from said content when it gets reported.
+
+Thank you for your report.
+
+`
+	// assert it's identical
+	actual := email.response()
+	if actual != expected {
+		t.Fatal(diff.LineDiff(expected, actual))
 	}
 
 	// add one blocked skylink and assert we get another template
@@ -127,14 +173,23 @@ func testTemplate(t *testing.T) {
 	email.ParseResult.Skylinks = []string{skylink}
 	email.BlockResult = []string{AbuseStatusBlocked}
 
-	// check whether it returns the appropriate template
-	if !hasString("following links were identified and blocked") {
-		t.Fatal("unexpected response", email.String())
-	}
+	expected = fmt.Sprintf(`Hello,
 
-	// assert the legal notice is set
-	if !hasString("no content is stored on our servers") {
-		t.Fatal("unexpected response", email.String())
+the following links were identified and blocked on all of our servers as of %s
+
+- EAC6rPvqSR8Mcp0ulwFvFHSYvCZsnsizCvDPxac8HiThjQ
+
+Please note that no content is stored on our servers, but rather on a decentralised network of hosts. 
+Therefore we are not to be held accountable for any potential abusive content it might contain.
+We will, however, do everything in our power to block access from said content when it gets reported.
+
+Thank you for your report.
+`, blockedAt.Format("Mon Jan _2 15:04:05 2006"))
+
+	// assert it's identical
+	actual = email.response()
+	if actual != expected {
+		t.Fatal("\n" + diff.LineDiff(expected, actual))
 	}
 
 	// add one skylink that we could not block for some reason
@@ -142,16 +197,26 @@ func testTemplate(t *testing.T) {
 	email.ParseResult.Skylinks = []string{skylink, skylink2}
 	email.BlockResult = []string{AbuseStatusBlocked, AbuseStatusNotBlocked}
 
-	// check whether it returns the appropriate template
-	if !hasString("following links were identified and blocked") {
-		t.Fatal("unexpected response", email.String())
-	}
-	if !hasString("following links could not be blocked") {
-		t.Fatal("unexpected response", email.String())
-	}
+	expected = fmt.Sprintf(`Hello,
 
-	// assert the legal notice is set
-	if !hasString("no content is stored on our servers") {
-		t.Fatal("unexpected response", email.String())
+the following links were identified and blocked on all of our servers as of %v
+
+- EAC6rPvqSR8Mcp0ulwFvFHSYvCZsnsizCvDPxac8HiThjQ
+
+the following links could not be blocked:
+
+- 4BHyW37RDVl_I475WfO-5FD8zNOBbSCYJ9U_C9n3yondMw
+
+Please note that no content is stored on our servers, but rather on a decentralised network of hosts. 
+Therefore we are not to be held accountable for any potential abusive content it might contain.
+We will, however, do everything in our power to block access from said content when it gets reported.
+
+Thank you for your report.
+`, blockedAt.Format("Mon Jan _2 15:04:05 2006"))
+
+	// assert it's identical
+	actual = email.response()
+	if actual != expected {
+		t.Fatal(diff.LineDiff(expected, actual))
 	}
 }

--- a/database/abuseemail_test.go
+++ b/database/abuseemail_test.go
@@ -1,0 +1,100 @@
+package database
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAbuseEmail is a collection of unit tests around the abuse email object.
+func TestAbuseEmail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "ResponseTemplate",
+			test: testResponseTemplate,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, test.test)
+	}
+}
+
+// testResponseTemplate verifies the implementation of the response template
+// method on the abuse email
+func testResponseTemplate(t *testing.T) {
+	// draft a dummy abuse email with all required fields set
+	email := AbuseEmail{
+		InsertedBy: "some-server.skynetlabs.com",
+		InsertedAt: time.Now(),
+
+		Blocked:   true,
+		BlockedAt: time.Now(),
+
+		Parsed:   true,
+		ParsedAt: time.Now(),
+		ParseResult: AbuseReport{
+			Reporter: AbuseReporter{
+				Name:  "Skynetlabs Dev Team",
+				Email: "devs@skynetlabs.com",
+			},
+			Skylinks: nil,
+			Sponsor:  "skynetlabs.com",
+			Tags:     []string{"csam"},
+		},
+		BlockResult: nil,
+	}
+
+	// small helper function that checks whether the given string is part of the
+	// abuse email's response template
+	hasString := func(s string) bool {
+		return strings.Contains(email.responseTemplate(), s)
+	}
+
+	// check whether it returns the appropriate template
+	if !hasString("were unable to find any valid links") {
+		t.Fatal("unexpected response", email.String())
+	}
+
+	// assert the legal notice is set
+	if !hasString("no content is stored on our servers") {
+		t.Fatal("unexpected response", email.String())
+	}
+
+	// add one blocked skylink and assert we get another template
+	skylink := "EAC6rPvqSR8Mcp0ulwFvFHSYvCZsnsizCvDPxac8HiThjQ"
+	email.ParseResult.Skylinks = []string{skylink}
+	email.BlockResult = []string{AbuseStatusBlocked}
+
+	// check whether it returns the appropriate template
+	if !hasString("following links were identified and blocked") {
+		t.Fatal("unexpected response", email.String())
+	}
+
+	// assert the legal notice is set
+	if !hasString("no content is stored on our servers") {
+		t.Fatal("unexpected response", email.String())
+	}
+
+	// add one skylink that we could not block for some reason
+	skylink2 := "4BHyW37RDVl_I475WfO-5FD8zNOBbSCYJ9U_C9n3yondMw"
+	email.ParseResult.Skylinks = []string{skylink, skylink2}
+	email.BlockResult = []string{AbuseStatusBlocked, AbuseStatusNotBlocked}
+
+	// check whether it returns the appropriate template
+	if !hasString("following links were identified and blocked") {
+		t.Fatal("unexpected response", email.String())
+	}
+	if !hasString("following links could not be blocked") {
+		t.Fatal("unexpected response", email.String())
+	}
+
+	// assert the legal notice is set
+	if !hasString("no content is stored on our servers") {
+		t.Fatal("unexpected response", email.String())
+	}
+}

--- a/database/abusescanner.go
+++ b/database/abusescanner.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -10,21 +9,11 @@ import (
 	lock "github.com/square/mongo-lock"
 	"gitlab.com/NebulousLabs/errors"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const (
-	// AbuseStatusBlocked denotes the blocked status.
-	AbuseStatusBlocked = "BLOCKED"
-
-	// AbuseStatusNotBlocked denotes the not blocked status.
-	AbuseStatusNotBlocked = "NOT BLOCKED"
-
-	// AbuseDefaultTag is the tag used when there are no tags found in the email
-	AbuseDefaultTag = "abusive"
-
 	// DBAbuseScanner defines the name of the mongo database used by the scanner
 	DBAbuseScanner = "abuse-scanner"
 
@@ -65,52 +54,6 @@ type (
 		staticPortalHostName string
 	}
 
-	// AbuseEmail represent an object in the emails collection.
-	AbuseEmail struct {
-		// fields set by fetcher
-		ID        primitive.ObjectID `bson:"_id"`
-		UID       string             `bson:"email_uid"`
-		UIDRaw    uint32             `bson:"email_uid_raw"`
-		Body      []byte             `bson:"email_body"`
-		From      string             `bson:"email_from"`
-		Subject   string             `bson:"email_subject"`
-		MessageID string             `bson:"email_message_id"`
-
-		InsertedBy string    `bson:"inserted_by"`
-		InsertedAt time.Time `bson:"inserted_at"`
-
-		Skip bool `bson:"skip"`
-
-		// fields set by parser
-		ParsedAt    time.Time   `bson:"parsed_at"`
-		ParseResult AbuseReport `bson:"parse_result"`
-		Parsed      bool        `bson:"parsed"`
-
-		// fields set by blocker
-		BlockedAt   time.Time `bson:"blocked_at"`
-		BlockResult []string  `bson:"block_result"`
-		Blocked     bool      `bson:"blocked"`
-
-		// fields set by finalizer
-		Finalized   bool      `bson:"finalized"`
-		FinalizedAt time.Time `bson:"finalized_at"`
-	}
-
-	// AbuseReport contains all information about an abuse report.
-	AbuseReport struct {
-		Skylinks []string      `bson:"skylinks"`
-		Reporter AbuseReporter `bson:"reporter"`
-		Sponsor  string        `bson:"sponsor"`
-		Tags     []string      `bson:"tags"`
-	}
-
-	// AbuseReporter encapsulates some information about the reporter.
-	AbuseReporter struct {
-		Name         string `bson:"name"`
-		Email        string `bson:"email"`
-		OtherContact string `bson:"other_contact"`
-	}
-
 	// abuseEmailLock represents a lock on an abuse email.
 	abuseEmailLock struct {
 		staticClient         *lock.Client
@@ -118,51 +61,6 @@ type (
 		staticPortalHostname string
 	}
 )
-
-// String returns a string representation of the abuse email
-func (a AbuseEmail) String() string {
-	var sb strings.Builder
-	pr := a.ParseResult
-	sb.WriteString("\nAbuse Scanner Report:\n")
-
-	sb.WriteString("\nServer:\n")
-	sb.WriteString(fmt.Sprintf("Domain: %v\n", a.InsertedBy))
-
-	sb.WriteString("\nReporter:\n")
-	sb.WriteString(fmt.Sprintf("Name: %v\n", pr.Reporter.Name))
-	sb.WriteString(fmt.Sprintf("Email: %v\n", pr.Reporter.Email))
-
-	sb.WriteString("\nTags:\n")
-	for _, tag := range pr.Tags {
-		sb.WriteString(tag + "\n")
-	}
-
-	allBlocked := true
-	sb.WriteString("\nSkylinks:\n")
-	for i, skylink := range pr.Skylinks {
-		var parts []string
-		if a.BlockResult[i] == AbuseStatusBlocked {
-			parts = []string{AbuseStatusBlocked, skylink}
-		} else {
-			parts = []string{AbuseStatusNotBlocked, skylink, a.BlockResult[i]}
-			allBlocked = false
-		}
-		sb.WriteString(fmt.Sprintf("%s\n", strings.Join(parts, " | ")))
-	}
-
-	sb.WriteString("\nSummary:\n")
-	if len(pr.Skylinks) == 0 {
-		sb.WriteString("FAILURE - no skylinks found.\n")
-	} else {
-		if allBlocked {
-			sb.WriteString("SUCCESS\n")
-		} else {
-			sb.WriteString("FAILURE - not all skylinks blocked.\n")
-		}
-	}
-
-	return sb.String()
-}
 
 // NewAbuseScannerDB returns an instance of the Mongo DB.
 func NewAbuseScannerDB(ctx context.Context, portalHostName, mongoUri, mongoDbName string, mongoCreds options.Credential, logger *logrus.Logger) (*AbuseScannerDB, error) {

--- a/email/parser.go
+++ b/email/parser.go
@@ -323,6 +323,7 @@ func extractTags(input []byte) []string {
 	copyright := regexp.MustCompile(`[Ii]nfringing`).Find(input) != nil
 	copyright = copyright || regexp.MustCompile(`[Cc]opyright`).Find(input) != nil
 	terrorism := regexp.MustCompile(`[Tt]error`).Find(input) != nil
+	terrorism = terrorism || regexp.MustCompile(`[Ii]slamic [Ss]tate`).Find(input) != nil
 	csam := regexp.MustCompile(`[Cc]hild`).Find(input) != nil
 	csam = csam || regexp.MustCompile(`CSAM`).Find(input) != nil
 	csam = csam || regexp.MustCompile(`csam`).Find(input) != nil

--- a/email/parser_test.go
+++ b/email/parser_test.go
@@ -201,6 +201,20 @@ func testExtractTags(t *testing.T) {
 	if tags[0] != "copyright" || tags[1] != "csam" || tags[2] != "malware" || tags[3] != "phishing" || tags[4] != "terrorism" {
 		t.Fatal("unexpected tags", tags)
 	}
+
+	// check whether islamic state is tagged as terrost content
+	exampleBody = []byte(`
+	This is an example of an email body that might contain links to islamic state propaganda.
+	`)
+
+	// extract the tags and assert we found all of them
+	tags = extractTags(exampleBody)
+	if len(tags) != 1 {
+		t.Fatalf("unexpected amount of tags found, %v != 1", len(tags))
+	}
+	if tags[0] != "terrorism" {
+		t.Fatal("unexpected tag", tags[0])
+	}
 }
 
 // testBuildAbuseReport is a unit test that verifies the functionality of the

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 
 require (
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
+	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 // indirect
 	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f // indirect
 	github.com/dchest/threefish v0.0.0-20120919164726-3ecf4c494abf // indirect
 	github.com/emersion/go-message v0.15.0 // indirect
@@ -27,6 +28,7 @@ require (
 	github.com/klauspost/reedsolomon v1.9.15 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/tus/tusd v1.8.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -416,6 +418,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
+github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0/go.mod h1:Ad7IjTpvzZO8Fl0vh9AzQ+j/jYZfyp2diGwI8m5q+ns=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=


### PR DESCRIPTION
# PULL REQUEST

## Overview

This is a small change to make Danger's life a bit easier, we add response template snippets to the abuse scanner report so when we have to reply manually the process can be copy-paste and make minor changes if necessary. Unfortunately, it'll still be a manual process but the goal is to eventually auto-send these responses. Before we can do that though, I would like to use these templates and then see whether they are good enough to auto-send as a reply to the original sender.

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
N/A