### PR TITLE
Lint dockerfile with hadolint

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -1,0 +1,16 @@
+name: Dockerfile Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v2.0.0
+        with:
+          dockerfile: Dockerfile


### PR DESCRIPTION
Lint dockerfile with https://github.com/hadolint/hadolint-action

ref. https://github.com/hadolint/hadolint

local scan: `docker run --rm -i hadolint/hadolint < Dockerfile`