### PR TITLE
Exclude Media Types 

### DIFF
--- a/email/parser.go
+++ b/email/parser.go
@@ -252,6 +252,10 @@ func parseBody(body []byte, logger *logrus.Entry) ([]string, []string, error) {
 			}
 
 			t, _, _ := p.Header.ContentType()
+			if !shouldParseMediaType(t) {
+				continue
+			}
+
 			switch t {
 			case "text/html":
 				// extract all text from the HTML
@@ -283,6 +287,11 @@ func parseBody(body []byte, logger *logrus.Entry) ([]string, []string, error) {
 	} else {
 		skylinks = extractSkylinks(body)
 		tags = extractTags(body)
+	}
+
+	// if we have not found any tags yet
+	if len(tags) == 0 {
+		tags = append(tags, database.AbuseDefaultTag)
 	}
 
 	return dedupe(skylinks), dedupe(tags), nil
@@ -378,11 +387,6 @@ func extractTags(input []byte) []string {
 		tags = append(tags, "csam")
 	}
 
-	// if we have not found any tags yet
-	if len(tags) == 0 {
-		tags = append(tags, database.AbuseDefaultTag)
-	}
-
 	return tags
 }
 
@@ -407,4 +411,13 @@ func extractTextFromHTML(r io.Reader) (string, error) {
 	}
 
 	return strings.Join(text, ""), nil
+}
+
+// shouldParseMediaType is a helper function that returns true if the given
+// media type is one that we should parse
+func shouldParseMediaType(mediaType string) bool {
+	return strings.HasPrefix(mediaType, "application") ||
+		strings.HasPrefix(mediaType, "message") ||
+		strings.HasPrefix(mediaType, "multipart") ||
+		strings.HasPrefix(mediaType, "text")
 }

--- a/email/parser_test.go
+++ b/email/parser_test.go
@@ -356,7 +356,7 @@ func testExtractTextFromHTML(t *testing.T) {
 func testExtractTags(t *testing.T) {
 	t.Parallel()
 
-	// base case, assert not tags are returned
+	// base case, assert no tags are returned
 	tags := extractTags(nil)
 	if len(tags) != 0 {
 		t.Fatalf("unexpected amount of tags found, %v != 0", len(tags))

--- a/email/parser_test.go
+++ b/email/parser_test.go
@@ -72,48 +72,68 @@ var (
 	  <img width="1" height="1" src="https://r.relay.hostkey.com/tr/op/aAMIbWQvCFUFW51yPO-mQwWdaGyPuvXUgRReI7L4Jg-v7wCrnpIWymrHdlMYdd5M6LNIEo-fcd6kxcD5KftPakp-3NrW3Z-dvYZ_KX54q8f5897S0HES-iPqJF3-uPx30Gu15Nax8rj16DaAgWW8eKHmKEZAGhMltg" alt="" /></body></html>
 	`
 
-	// multipartAlternativeBody is an example email body that uses the
-	// content-type multipart/mixed and multipart/alternative to ensure in
-	// testing we parse those parts of the email body properly
-	multipartAlternativeBody = `Delivered-To: report@siasky.net
-	Received: by 2002:a05:7000:a1a:0:0:0:0 with SMTP id ke26csp576371mab;
-			Sun, 26 Jun 2022 23:29:59 -0700 (PDT)
-	Date: Mon, 27 Jun 2022 09:29:55 +0300
-	From: =obfuscated<phishing@obfuscated.com>
-	To: response@cert-gib.ru, abuse@namecheap.com, abuse@siasky.net
-	Subject: [Ticket#22062706295325258] Phishing site
-	MIME-Version: 1.0
-	Content-Type: multipart/mixed; 
-			boundary="----=_Part_71086_603584994.1656311395405"
-	------=_Part_71086_603584994.1656311395405
-	Content-Type: multipart/alternative; 
-			boundary="----=_Part_71087_1111859740.1656311395408"
-	
-	------=_Part_71087_1111859740.1656311395408
-	Content-Type: text/plain; charset=utf-8
-	Content-Transfer-Encoding: quoted-printable
-	
-	Hi,
-	=EF=BB=BF
-	The bad news is you are hosting a phishing site:
-	https://siasky.net/BACCHn5eHow5edoimjiwBtD2ErM3OL57mf-_MghKeebanA#abuse%40y=
-	andex.ru
-	
-	The good news is that now that you know about this scam you can stop it. Pl=
-	ease shut this site down.
-	
-	It would also help us greatly to prevent any phishing activity in the futur=
-	e, if you could provide us with the source code of this site and any data t=
-	hat has already been stolen so that we could use them for analysis.
+	// contentTypeBody is an example email body that uses a bunch of different
+	// content types to ensure in testing we parse those parts of the email body
+	// properly
+	contentTypeBody = `Delivered-To: report@siasky.net
+Received: by 2002:a05:7000:a1a:0:0:0:0 with SMTP id ke26csp576371mab;
+        Sun, 26 Jun 2022 23:29:59 -0700 (PDT)
+Date: Mon, 27 Jun 2022 09:29:55 +0300
+From: =obfuscated<phishing@obfuscated.com>
+To: response@cert-gib.ru, abuse@namecheap.com, abuse@siasky.net
+Subject: [Ticket#22062706295325258] Phishing site
+MIME-Version: 1.0
+Content-Type: multipart/mixed; 
+        boundary="----=_Part_71086_603584994.1656311395405"
 
-	------=_Part_71087_1111859740.1656311395408
-	Content-Type: text/html; charset=utf-8
-	Content-Transfer-Encoding: 7bit
-	
-	<p>Hi,<br />&#xfeff;<br />The bad news is you are hosting a phishing site:<br /><a href="https://siasky.net/BACCHn5eHow5edoimjiwBtD2ErM3OL57mf-_MghKeebanA#abuse%obfuscated.ru" rel="nofollow">https://siasky.net/BACCHn5eHow5edoimjiwBtD2ErM3OL57mf-_MghKeebanA#abuse%40yandex.ru</a></p><br /><p>The good news is that now that you know about this scam you can stop it. Please shut this site down.</p><br /><p>It would also help us greatly to prevent any phishing activity in the future, if you could provide us with the source code of this site and any data that has already been stolen so that we could use them for analysis.</p><br /><p>--<br /><a href="https://forms.yandex.ru/surveys/10012037/?theme&#61;support-vote&amp;iframe&#61;1&amp;lang&#61;en&amp;session&#61;a20d99e6-2969-3f30-a04f-1a1b6935c3b8" rel="nofollow">Please rate our reply</a></p><br /><p>Some One<br />Support team<br /><a href="https://obfuscated.com/support/" rel="nofollow">https://obfuscated.com/support/</a></p>
-	------=_Part_71087_1111859740.1656311395408--
-	`
+------=_Part_71086_603584994.1656311395405
+Content-Type: multipart/alternative; 
+        boundary="----=_Part_71087_1111859740.1656311395408"
 
+------=_Part_71087_1111859740.1656311395408
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hi,
+=EF=BB=BF
+The bad news is you are hosting a phishing site:
+https://siasky.net/BACCHn5eHow5edoimjiwBtD2ErM3OL57mf-_MghKeebanA#abuse%40y=
+andex.ru
+
+The good news is that now that you know about this scam you can stop it. Pl=
+ease shut this site down.
+
+It would also help us greatly to prevent any phishing activity in the futur=
+e, if you could provide us with the source code of this site and any data t=
+hat has already been stolen so that we could use them for analysis.
+
+------=_Part_71087_1111859740.1656311395408
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<p>Hi,<br />&#xfeff;<br />The bad news is you are hosting a phishing site:<br /><a href="https://siasky.net/BACCHn5eHow5edoimjiwBtD2ErM3OL57mf-_MghKeebanA#abuse%obfuscated.ru" rel="nofollow">https://siasky.net/BACCHn5eHow5edoimjiwBtD2ErM3OL57mf-_MghKeebanA#abuse%40yandex.ru</a></p><br /><p>The good news is that now that you know about this scam you can stop it. Please shut this site down.</p><br /><p>It would also help us greatly to prevent any phishing activity in the future, if you could provide us with the source code of this site and any data that has already been stolen so that we could use them for analysis.</p><br /><p>--<br /><a href="https://forms.yandex.ru/surveys/10012037/?theme&#61;support-vote&amp;iframe&#61;1&amp;lang&#61;en&amp;session&#61;a20d99e6-2969-3f30-a04f-1a1b6935c3b8" rel="nofollow">Please rate our reply</a></p><br /><p>Some One<br />Support team<br /><a href="https://obfuscated.com/support/" rel="nofollow">https://obfuscated.com/support/</a></p>
+------=_Part_71087_1111859740.1656311395408--
+
+------=_Part_71086_603584994.1656311395405
+Content-Type: application/octet-stream; name=image.png
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename=image.png
+
+iVBORw0KGgoAAAANSUhEUgAAB4AAAAPtCAIAAADg5eUGAAAgAElEQVR4nOzd+7ddZX0/+vwFhJ/6
+BADCHn5eHow5edoimjiwBtD2ErM3OL57mf-_MghKeebanAqq1oQSOZXa4le09KsIiFzUEUPFfgvV
+QIJRAW1FTUyC7HCNkgDJPs/ec+25522t9ay911xz7vB6jc/Ateea81nPXLexfe8nn7ng6KNO7l3H
+------=_Part_71086_603584994.1656311395405
+
+------=_Part_71086_603584994.1656311395405
+Content-Type: image/png
+Content-Transfer-Encoding: base64
+Content-ID: <6B7613EB-E52E-44C0-9A21-DC3B25738265>
+Content-Disposition: inline; filename="Screenshot 2022-06-21 at 10.59.37.png"
+
+------=_Part_71086_603584994.1656311395405--`
+
+	// unknownCharsetBody is an example body that uses a character set that is
+	// not supported by default
 	unknownCharsetBody = `Received: by 2002:a05:7000:ae16:0:0:0:0 with SMTP id ij22csp429885mab;
 	Thu, 31 Mar 2022 01:17:25 -0700 (PDT)
 Content-Type: text/plain; charset="iso-8859-1"
@@ -144,6 +164,7 @@ func TestParser(t *testing.T) {
 	t.Run("ExtractTags", testExtractTags)
 	t.Run("ExtractTextFromHTML", testExtractTextFromHTML)
 	t.Run("ParseBody", testParseBody)
+	t.Run("ShouldParseMediaType", testShouldParseMediaType)
 }
 
 // testParseBody is a unit test that covers the functionality of the parseBody helper
@@ -154,8 +175,8 @@ func testParseBody(t *testing.T) {
 	logger := logrus.New()
 	logger.Out = ioutil.Discard
 
-	// parse our example body for various multiparts
-	skylinks, tags, err := parseBody([]byte(multipartAlternativeBody), logger.WithField("module", "Parser"))
+	// parse our example body with multipart content
+	skylinks, tags, err := parseBody([]byte(contentTypeBody), logger.WithField("module", "Parser"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -335,13 +356,10 @@ func testExtractTextFromHTML(t *testing.T) {
 func testExtractTags(t *testing.T) {
 	t.Parallel()
 
-	// base case, assert the abusive tags is returned of no others were found
+	// base case, assert not tags are returned
 	tags := extractTags(nil)
-	if len(tags) != 1 {
-		t.Fatalf("unexpected amount of tags found, %v != 1", len(tags))
-	}
-	if tags[0] != database.AbuseDefaultTag {
-		t.Fatal("unexpected tag", tags[0])
+	if len(tags) != 0 {
+		t.Fatalf("unexpected amount of tags found, %v != 0", len(tags))
 	}
 
 	// use a made up email body that contains all tags
@@ -464,5 +482,62 @@ func testBuildAbuseReport(t *testing.T) {
 	}
 	if pr.Reporter.Email != "someone@gmail.com" {
 		t.Fatal("unexpected reporter", pr.Reporter.Email)
+	}
+}
+
+// testShouldParseMediaType is a unit test that covers the ShouldParseMediaType helper function
+func testShouldParseMediaType(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		mediaType   string
+		shouldParse bool
+	}{
+		{
+			mediaType:   "application/json",
+			shouldParse: true,
+		},
+		{
+			mediaType:   "audio/mp4",
+			shouldParse: false,
+		},
+		{
+			mediaType:   "font/otf",
+			shouldParse: false,
+		},
+		{
+			mediaType:   "example/foo",
+			shouldParse: false,
+		},
+		{
+			mediaType:   "image/png",
+			shouldParse: false,
+		},
+		{
+			mediaType:   "message/example",
+			shouldParse: true,
+		},
+		{
+			mediaType:   "model/example",
+			shouldParse: false,
+		},
+		{
+			mediaType:   "multipart/mixed",
+			shouldParse: true,
+		},
+		{
+			mediaType:   "text/html",
+			shouldParse: true,
+		},
+		{
+			mediaType:   "video/mp4",
+			shouldParse: false,
+		},
+	}
+
+	for _, tt := range cases {
+		if output := shouldParseMediaType(tt.mediaType); output != tt.shouldParse {
+			t.Errorf("unexpected outcome for media type '%v', %v != %v", tt.mediaType, output, tt.shouldParse)
+		}
 	}
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR fixes a unit test which was not properly testing a certain code path due to some tabs that got introduced by copy pasting. It also adds a helper function that filters certain media types so the parser can skip them, things like audio/video/images.

## Example for Visual Changes

N/A

## Checklist

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [x] Testing added or updated for new methods.
- [x] Verified if any changes impact the WebPortal Health Checks.
- [x] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

Closes SKY-1163