### PR TITLE
[MINOR] Abuse Email Metadata

### DIFF
--- a/database/abuseemail.go
+++ b/database/abuseemail.go
@@ -67,6 +67,7 @@ type (
 		// fields set by reporter
 		Reported   bool      `bson:"reported"`
 		ReportedAt time.Time `bson:"reported_at"`
+		ReportedBy string    `bson:"reported_by"`
 	}
 
 	// AbuseReport contains all information about an abuse report.

--- a/email/blocker_test.go
+++ b/email/blocker_test.go
@@ -1,0 +1,144 @@
+package email
+
+import (
+	"abuse-scanner/database"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	skyapi "gitlab.com/SkynetLabs/skyd/node/api"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.sia.tech/siad/build"
+)
+
+// TestBlocker contains a set of unit tests that cover the blocker struct.
+func TestBlocker(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "Blocker",
+			test: testBlocker,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, test.test)
+	}
+}
+
+// testBlocker covers the functionality of the blocker
+func testBlocker(t *testing.T) {
+	// create a context w/timeout
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	// create a null logger
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+
+	// create the abuse databases
+	abuseDBName := t.Name() + "_AbuseDB"
+	abuseDB, err := database.NewTestAbuseScannerDB(ctx, abuseDBName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := abuseDB.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// create a test server that returns a mocked response indicating all is ok
+	mux := http.NewServeMux()
+	mux.HandleFunc("/block", func(w http.ResponseWriter, r *http.Request) {
+		skyapi.WriteSuccess(w)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// create a blocker
+	domain := "dev.siasky.net"
+	bl := NewBlocker(ctx, server.URL, domain, abuseDB, logger)
+
+	// insert an email to report
+	insertedAt := time.Now().UTC()
+	email := database.AbuseEmail{
+		ID:  primitive.NewObjectID(),
+		UID: "INBOX-0",
+
+		Parsed:    true,
+		Blocked:   false,
+		Finalized: false,
+		Reported:  false,
+
+		ParseResult: database.AbuseReport{
+			Tags:     []string{"csam"},
+			Skylinks: []string{sl1}},
+
+		InsertedAt: insertedAt,
+	}
+	err = abuseDB.InsertOne(email)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert there's one unblocked email
+	unblocked, err := abuseDB.FindUnblocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unblocked) != 1 {
+		t.Fatalf("unexpected number of unblocked emails, %v != 1", len(unblocked))
+	}
+
+	// start the blocker
+	err = bl.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// defer stop
+	defer func() {
+		if err := bl.Stop(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// assert there's no unreported emails left in a retry
+	err = build.Retry(100, 100*time.Millisecond, func() error {
+		unblocked, err := abuseDB.FindUnblocked()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(unblocked) != 0 {
+			return fmt.Errorf("unexpected number of unblocked emails, %v != 0", len(unblocked))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert the blocked_by parameter was set
+	blocked, err := abuseDB.FindOne("INBOX-0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked.BlockedBy != domain {
+		t.Fatal("unexpected blocked_by value", email.BlockedBy)
+	}
+
+	// call cancel so we can cleanly stop the blocker
+	cancel()
+}

--- a/email/fetcher.go
+++ b/email/fetcher.go
@@ -415,8 +415,5 @@ func hasBody(msg *imap.Message) bool {
 		return false
 	}
 	bodyLit := msg.GetBody(sectionName)
-	if bodyLit == nil {
-		return false
-	}
-	return true
+	return bodyLit != nil
 }

--- a/email/parser.go
+++ b/email/parser.go
@@ -18,8 +18,6 @@ import (
 	"gitlab.com/SkynetLabs/skyd/skymodules"
 	"go.mongodb.org/mongo-driver/bson"
 	"golang.org/x/net/html"
-
-	_ "github.com/emersion/go-message/charset"
 )
 
 const (

--- a/email/parser.go
+++ b/email/parser.go
@@ -18,6 +18,8 @@ import (
 	"gitlab.com/SkynetLabs/skyd/skymodules"
 	"go.mongodb.org/mongo-driver/bson"
 	"golang.org/x/net/html"
+
+	_ "github.com/emersion/go-message/charset"
 )
 
 const (
@@ -151,16 +153,14 @@ func (p *Parser) parseEmail(email database.AbuseEmail) (err error) {
 	}
 
 	// update the email
-	err = abuseDB.UpdateNoLock(email,
-		bson.D{
-			{"$set", bson.D{
-				{"parsed", true},
-				{"parsed_at", time.Now().UTC()},
-				{"parsed_by", p.staticServerDomain},
-				{"parse_result", report},
-			}},
+	err = abuseDB.UpdateNoLock(email, bson.M{
+		"$set": bson.M{
+			"parsed":       true,
+			"parsed_at":    time.Now().UTC(),
+			"parsed_by":    p.staticServerDomain,
+			"parse_result": report,
 		},
-	)
+	})
 	if err != nil {
 		return errors.AddContext(err, "could not update email")
 	}

--- a/email/parser_test.go
+++ b/email/parser_test.go
@@ -466,6 +466,9 @@ func testBuildAbuseReport(t *testing.T) {
 	if updated.Finalized {
 		t.Fatal("expected the email to not be finalized")
 	}
+	if updated.ParsedBy != domain {
+		t.Fatal("expected the parsed_by field to be set")
+	}
 
 	// assert the parse result, note that we don't deep equal the parse result,
 	// since we use the example email body we can rest assured it's correct

--- a/email/reporter.go
+++ b/email/reporter.go
@@ -55,13 +55,14 @@ type (
 		staticLogger         *logrus.Entry
 		staticPortalURL      string
 		staticReporter       NCMECReporter
+		staticServerDomain   string
 		staticStopChan       chan struct{}
 		staticWaitGroup      sync.WaitGroup
 	}
 )
 
 // NewReporter creates a new reporter.
-func NewReporter(abuseDB *database.AbuseScannerDB, accountsClient accounts.AccountsAPI, creds NCMECCredentials, portalURL string, reporter NCMECReporter, logger *logrus.Logger) *Reporter {
+func NewReporter(abuseDB *database.AbuseScannerDB, accountsClient accounts.AccountsAPI, creds NCMECCredentials, portalURL, serverDomain string, reporter NCMECReporter, logger *logrus.Logger) *Reporter {
 	return &Reporter{
 		staticAbuseDatabase:  abuseDB,
 		staticAccountsClient: accountsClient,
@@ -70,6 +71,7 @@ func NewReporter(abuseDB *database.AbuseScannerDB, accountsClient accounts.Accou
 		staticLogger:         logger.WithField("module", "Reporter"),
 		staticPortalURL:      portalURL,
 		staticReporter:       reporter,
+		staticServerDomain:   serverDomain,
 		staticStopChan:       make(chan struct{}),
 	}
 }
@@ -220,6 +222,7 @@ func (r *Reporter) buildReportsForEmail(email database.AbuseEmail) error {
 	err = abuseDB.UpdateNoLock(email, bson.M{
 		"$set": bson.M{
 			"reported":    true,
+			"reported_by": r.staticServerDomain,
 			"reported_at": time.Now().UTC(),
 		},
 	})

--- a/email/reporter_test.go
+++ b/email/reporter_test.go
@@ -220,7 +220,7 @@ func testReporter(t *testing.T) {
 	}
 
 	// assert there's no unfiled reports left in a retry
-	err = build.Retry(100, 100*time.Millisecond, func() error {
+	err = build.Retry(30, time.Second, func() error {
 		unfiled, err := abuseDB.FindUnfiledReports()
 		if err != nil {
 			t.Fatal(err)
@@ -246,6 +246,9 @@ func testReporter(t *testing.T) {
 	}
 	if reported.ReportedAt == (time.Time{}) {
 		t.Fatal("unexpected reported at", reported.ReportedAt)
+	}
+	if reported.ReportedBy != "eu-pol-2.siasky.net" {
+		t.Fatal("unexpected reported by field", reported.ReportedBy)
 	}
 
 	// draft the 3 reports we expect

--- a/email/reporter_test.go
+++ b/email/reporter_test.go
@@ -153,7 +153,7 @@ func testReporter(t *testing.T) {
 	// create a reporter
 	accountsMock := mockAccountsClient{}
 	reporter := newTestReporter()
-	r := NewReporter(abuseDB, accountsMock, creds, "https://siasky.net", reporter, logger)
+	r := NewReporter(abuseDB, accountsMock, creds, "https://siasky.net", "eu-pol-2.siasky.net", reporter, logger)
 
 	// insert an email to report
 	insertedAt := time.Now().UTC()

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/klauspost/reedsolomon v1.9.15 // indirect
+	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/tus/tusd v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -385,6 +385,7 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func main() {
 	// parsed but not blocked yet, it uses the blocker API for this.
 	logger.Info("Initializing blocker...")
 	blockerApiUrl := fmt.Sprintf("http://%s:%s", blockerHost, blockerPort)
-	blocker := email.NewBlocker(ctx, blockerApiUrl, abuseDB, logger)
+	blocker := email.NewBlocker(ctx, blockerApiUrl, serverDomain, abuseDB, logger)
 	err = blocker.Start()
 	if err != nil {
 		log.Fatal("Failed to start the blocker, err: ", err)
@@ -148,7 +148,7 @@ func main() {
 		accountsClient := accounts.NewAccountsClient(accountsHost, accountsPort)
 
 		logger.Info("Initializing reporter...")
-		reporter := email.NewReporter(abuseDB, accountsClient, ncmecCredentials, abusePortalURL, ncmecReporter, logger)
+		reporter := email.NewReporter(abuseDB, accountsClient, ncmecCredentials, abusePortalURL, serverDomain, ncmecReporter, logger)
 		err = reporter.Start()
 		if err != nil {
 			log.Fatal("Failed to start the NCMEC reporter, err: ", err)


### PR DESCRIPTION
# PULL REQUEST

## Overview

Whilst debugging I noticed a couple of metadata fields were missing on the abuse emails, namely:
- blocked_by
- reported_by
- parsed_by

These fields have no real use aside from adding some metadata which can be helpful during debugging, so I decided to add them.

## Example for Visual Changes

N/A

## Checklist

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [x] Testing added or updated for new methods.
- [x] Verified if any changes impact the WebPortal Health Checks.
- [x] Appropriate documentation updated.
- [x] Changelog file created.

## Issues Closed

Closes SKY-1167