### PR TITLE
Update Parser Regex

### DIFF
--- a/email/parser.go
+++ b/email/parser.go
@@ -37,14 +37,14 @@ var (
 
 	// extractSkylink32RE and extractSkylink32RE_2 are regexes capable of
 	// extracting base-32 encoded skylinks from text
-	extractSkylink32RE   = regexp.MustCompile(`.+?://.*?([a-zA-Z0-9-_]{55})`)
-	extractSkylink32RE_2 = regexp.MustCompile(`(http.+|hxxp.+|\..+|://.+|^)([a-zA-Z0-9-_]{55})(\?.*)?$`)
+	extractSkylink32RE   = regexp.MustCompile(`(?i).+?://.*?([a-z0-9]{55})`)
+	extractSkylink32RE_2 = regexp.MustCompile(`(?i)(http.+|hxxp.+|\..+|://.+|^)([a-z0-9]{55})(\?.*)?$`)
 
 	// space matches all whitespace
 	space = regexp.MustCompile(`\s+`)
 
 	validateSkylink64RE = regexp.MustCompile(`^([a-zA-Z0-9-_]{46})$`)
-	validateSkylink32RE = regexp.MustCompile(`^([a-zA-Z0-9-_]{55})$`)
+	validateSkylink32RE = regexp.MustCompile(`(?i)^([a-z0-9]{55})$`)
 )
 
 type (

--- a/email/parser_test.go
+++ b/email/parser_test.go
@@ -285,7 +285,7 @@ func testExtractSkylinks(t *testing.T) {
 
 	hxxps:// [.] eu-ger-1 [.] siasky [.] net / 1005m6ki628f5t2o74h1qirph34lcavbn52oj7e2oan533sj3cgbr1o
 
-	hxxps:// [.] eu-ger-1 [.] siasky [.] net2005m6ki628f5t2o74h1qirph34lcavbn52oj7e2oan533sj3cgbr2b
+	hxxps:// [.] eu-ger-1 [.] siasky [.] net2005m6KI628f5t2o74h1qirph34lcavbn52oj7e2oan533sj3cgbr2b
 
 	3005m6ki628f5t2o74h1qirph34lcavbn52oj7e2oan533sj3cgbr2b
 	`))

--- a/email/parser_test.go
+++ b/email/parser_test.go
@@ -46,6 +46,9 @@ var (
 	hxxps:// siasky [.] net/CADEnmNNR6arnyDSH60MlGjQK5O3Sv-ecK1PGt3MNmQUhA#apg@franklinbank [.] com
 	hxxps:// siasky [.] net/GABJJhT8AlfNh-XS-6YVH8en7O-t377ej9XS2eclnv2yFg
 
+	https:// siasky [.]netAAAg4mZrsNcedNPazZ4kSFAYBzf7f8ZgHO1Tu1L-NN8Gjg
+	BBBg4mZrsNcedNPazZ4kSFAYBzf7f8ZgHO1Tu1L-NN8Gjg
+
 	As a reminder, phishing is expressly prohibited by our Universal Terms of Service Agreement, paragraph 7. "Acceptable Use Policy (AUP)"
 	`)
 
@@ -254,17 +257,21 @@ func testExtractSkylinks(t *testing.T) {
 
 	// extract skylinks
 	skylinks = extractSkylinks(exampleBody)
-	if len(skylinks) != 4 {
-		t.Fatalf("unexpected amount of skylinks found, %v != 4", len(skylinks))
+	sort.Strings(skylinks)
+	if len(skylinks) != 6 {
+		t.Fatalf("unexpected amount of skylinks found, %v != 6, skylinks %+v", len(skylinks), skylinks)
 	}
 
 	// assert we have extracted the correct skylinks
 	//
 	// NOTE: we didn't discover IGzqsAmjjLJjN3Or8ZFb9AGX4Km12EJu5AVmgaX8HWNy7Q
 	// which could have been a false positive as it's a valid skylink
-	sort.Strings(skylinks)
-	if skylinks[0] != "CADEnmNNR6arnyDSH60MlGjQK5O3Sv-ecK1PGt3MNmQUhA" ||
-		skylinks[1] != "GABJJhT8AlfNh-XS-6YVH8en7O-t377ej9XS2eclnv2yFg" || skylinks[2] != "GAEE7l0IkIVcVEHDgRCcNkRYS8keZKr9v_ffxf9_614m6g" || skylinks[3] != "nAA_hbtNaOYyR2WrM9UNIc5jRu4WfGy5QK_iTGosDgLmSA" {
+	if skylinks[0] != "AAAg4mZrsNcedNPazZ4kSFAYBzf7f8ZgHO1Tu1L-NN8Gjg" ||
+		skylinks[1] != "BBBg4mZrsNcedNPazZ4kSFAYBzf7f8ZgHO1Tu1L-NN8Gjg" ||
+		skylinks[2] != "CADEnmNNR6arnyDSH60MlGjQK5O3Sv-ecK1PGt3MNmQUhA" ||
+		skylinks[3] != "GABJJhT8AlfNh-XS-6YVH8en7O-t377ej9XS2eclnv2yFg" ||
+		skylinks[4] != "GAEE7l0IkIVcVEHDgRCcNkRYS8keZKr9v_ffxf9_614m6g" ||
+		skylinks[5] != "nAA_hbtNaOYyR2WrM9UNIc5jRu4WfGy5QK_iTGosDgLmSA" {
 		t.Fatal("unexpected skylinks", skylinks)
 	}
 
@@ -277,9 +284,13 @@ func testExtractSkylinks(t *testing.T) {
 	hxxps:// 7g01n1fmusamd3k4c5l7ahb39356rfhfs92e9mjshj1vq93vk891m2o [.] siasky [.] net
 
 	hxxps:// [.] eu-ger-1 [.] siasky [.] net / 1005m6ki628f5t2o74h1qirph34lcavbn52oj7e2oan533sj3cgbr1o
+
+	hxxps:// [.] eu-ger-1 [.] siasky [.] net2005m6ki628f5t2o74h1qirph34lcavbn52oj7e2oan533sj3cgbr2b
+
+	3005m6ki628f5t2o74h1qirph34lcavbn52oj7e2oan533sj3cgbr2b
 	`))
-	if len(skylinks) != 2 {
-		t.Fatalf("unexpected amount of skylinks found, %v != 2", len(skylinks))
+	if len(skylinks) != 4 {
+		t.Fatalf("unexpected amount of skylinks found, %v != 4, skylinks: %v", len(skylinks), skylinks)
 	}
 
 	// NOTE: it will have loaded the base32 encoded version Skylink and output
@@ -474,7 +485,7 @@ func testBuildAbuseReport(t *testing.T) {
 	// since we use the example email body we can rest assured it's correct
 	// since the unit tests cover that as well
 	pr := updated.ParseResult
-	if len(pr.Skylinks) != 4 {
+	if len(pr.Skylinks) != 6 {
 		t.Fatal("unexpected amount of skylinks", pr.Skylinks)
 	}
 	if len(pr.Tags) != 1 {


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR updates the parser regex to catch a skylink that was missed by the parser in an abuse report.
I've updated the regexes and the parser in a way that will detect the missed skylink format (and also other formats that were undetectable up until now), without causing any false positives (which we **definitely do not want** since we have automated replies now)

The format the skylink was reported at looked like this:
`https:// siasky [.]netEABg4mZrsNcedNPazZ4kSFAYBzf7f8ZgHO1Tu1L-NN8Gjg`
It's hard to believe the scanner didn't catch this, but it's missing the `/` after `net`.

The reason that extracting skylinks from these texts is harder than it seems, is that sometimes the email body contains headers that look like this:

```
X-UI-Out-Filterresults: notjunk:1;V03:K0:sQbC5Bf/7VA=:BVBvnd1QjaGT0MiZL1Ho9A
	 IfQpxAOa2PG7BhMwdjkSKRkIi/0Xi320ptoRVrfdAAfeBr+OlbE7g1lSC70AY1aq/+Fpbv4wK
	 3w2N9ynN89sZ8DCaJdB7ly3XgvTsG63gsWdX8Qx0neby0Ej1pajsGSgib3Zm8tezcKH7kM+uH
	 8vULEwVR983S1CyJCBaD2LqZ2TmObmdS+5OJ/edFn2tq2WoPNrpgdm2AFO0gTOwQJ7h7ZG7Cw
	 C51GLljzSwED8mirSv3crcZeIBAS1Id6HFLPoaPWp4PveU/v0K8KtULYo7z19AK6hQgwViBiU
	 Xq2l7J/I405Ww4d83HRzSQk5RYrUot3RK7Z1kuWHlS2xZrnuwbD/O/2jZ1wqm8ODWogMHSGkU
	 I98W13ylJ0OsjeGFO+nsutUv3MjInhjUV3BBvOsnOMPOEOB6O6XEm1wr4UtjHcc9NUBPBvNh9
	 H+gscpw0FrvBbZa+9XSyucw0nXv8ux6AcRDIkceD/k7QPuQ9qF7tieTcu08DuYDQn9NyBefCl
	 RgFTNK0mc/IGzqsAmjjLJjN3Or8ZFb9AGX4Km12EJu5AVmgaX8HWNy7TkwU/G/8fRhwNm1MZA
	 tvKIzaih0+MQ3vhyhX68w4FaCyw03DtqUuXiWc/B+ieWBognxojBZW8fnl6gh1JAtvlo0LKQp
	 GMyXa9CB0//7vKj4QzhelXKBJJgYM8711kf0IFnD84KydbfFnV0LupfaJ57SHxX6EQpsO8YE5
	 Q3y3pDDyLVRM6fCl4EjRAoVRJTN+cWfVrqR2XbR8PzsEhgLpvc0oqDoNuLLFLc9tNZyVRm+3M
	 NDkpXctNC4+MD8zqzyiDiRUOZ27w9qeZqUIEqMlbnpmYnILxrfZL8A5WXYajQ5BDUYi1oMT4W
	 UT47J3cxaP66B+03lzJqMDPAxGGzBoH4buNH0ku66gi0xcmhQtBcWhfDsGM9V9RSXeG/2FmHI
	 i4y3714s6I4zN5G7Fr7EPgg61IkFB+swtoo1O5WrNJ+jFWe5nIsCXWCinXRZgaD4Q2/+57VP5
	 idJHzNoSCPhRv6mwO/9+ia/4pVxgU8wVX6huAHRsFD2WkmpU42jsBGiWOwFj43HTwPuBxfBH9
	 VhQDFA5VMxSpI+4TBiXX9ZYWqnKGpBoBtfKDHqGxF5C1JqWv2xMsiUD9c43po1Z9SsfBEC2A5
	 cfV/KfZ5odL68cjZ0s7OQXt36o
```

which would label `YM8711kf0IFnD84KydbfFnV0LupfaJ57SHxX6EQpsO8YE5` as a valid skylink.

There was a second shortcoming of the parser I've fixed which is that up until now it was incapable of detecting the raw link on its own line, which is also hard to believe but people are simply reporting it using obfuscated urls.

## Example for Visual Changes

N/A

## Checklist

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [x] Testing added or updated for new methods.
- [ ] Verified if any changes impact the WebPortal Health Checks.
- [ ] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

Closes SKY-1207

