### PR TITLE
SkynetTransfer Parser Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 
 RUN go mod download && make release
 
-FROM alpine:3.15.4
+FROM docker:dind
 LABEL maintainer="SkynetLabs <devs@skynetlabs.com>"
 
 COPY --from=builder /go/bin/abuse-scanner /usr/bin/abuse-scanner

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,6 @@ test-long: lint start-mongo test-long-ci stop-mongo
 # be initailized separately
 test-long-ci:
 	@mkdir -p cover
-	GORACE='$(racevars)' go test -race --coverprofile='./cover/cover.out' -v -failfast -tags='testing debug netgo' -timeout=60s $(pkgs) -run=$(run) -count=$(count)
+	GORACE='$(racevars)' go test -race --coverprofile='./cover/cover.out' -v -failfast -tags='testing debug netgo' -timeout=10m $(pkgs) -run=$(run) -count=$(count)
 
 .PHONY: all deps fmt vet lint release start-mongo stop-mongo markdown-spellcheck test test-long test-long-ci

--- a/email/parser.go
+++ b/email/parser.go
@@ -530,7 +530,7 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 		return nil, err
 	}
 
-	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("~/skynet-webportal/docker/data/abuse-scanner/%v:/e2e", filepath.Base(dir)), "-w", "/e2e", "cypress/included:10.3.0")
+	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("/home/user/skynet-webportal/docker/data/abuse-scanner/%v:/e2e", filepath.Base(dir)), "-w", "/e2e", "cypress/included:10.3.0")
 	logger.Debugf("executing cmd %v", cmd.String())
 	var out bytes.Buffer
 	var stderr bytes.Buffer

--- a/email/parser.go
+++ b/email/parser.go
@@ -530,7 +530,7 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 		return nil, err
 	}
 
-	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("/home/user/skynet-webportal/docker/data/abuse-scanner/%v:/e2e", filepath.Base(dir)), "-w", "/e2e", "cypress/included:10.3.0")
+	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("abuse-scanner/%v:/e2e", filepath.Base(dir)), "-w", "/e2e", "cypress/included:10.3.0")
 	logger.Debugf("executing cmd %v", cmd.String())
 	var out bytes.Buffer
 	var stderr bytes.Buffer

--- a/email/parser.go
+++ b/email/parser.go
@@ -530,7 +530,7 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 		return nil, err
 	}
 
-	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("/tmp/abuse-scanner/%v:/e2e", filepath.Base(dir)), "-w", "/e2e", "cypress/included:10.3.0")
+	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("/tmp/abuse-scanner/%v:/e2e", filepath.Base(dir)), "-w", "/e2e", "cypress/included:10.3.0") //nolint:gosec
 	logger.Debugf("executing cmd %v", cmd.String())
 	var out bytes.Buffer
 	var stderr bytes.Buffer

--- a/email/parser.go
+++ b/email/parser.go
@@ -340,6 +340,7 @@ func parseBody(body []byte, logger *logrus.Entry) ([]string, []string, error) {
 
 	// if we have found skytransfer URLs, resolve them to skylinks
 	if len(skytransferURLs) > 0 {
+		logger.Info("FOUND SKYTRANSFER URLS", len(skytransferURLs))
 		resolvedSkylinks, err := resolveSkyTransferURLs(skytransferURLs, logger.Logger)
 		if err != nil {
 			fmt.Println(err)
@@ -347,6 +348,8 @@ func parseBody(body []byte, logger *logrus.Entry) ([]string, []string, error) {
 		} else {
 			skylinks = append(skylinks, resolvedSkylinks...)
 		}
+	} else {
+		logger.Info("NO SKYTRANSFER URLS FOUND")
 	}
 
 	return dedupe(skylinks), dedupe(tags), nil
@@ -511,7 +514,8 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 	if err != nil {
 		return nil, errors.AddContext(err, "could not create temporary directory")
 	}
-	defer os.RemoveAll(dir)
+	logger.Info("TMP DIR", dir)
+	// defer os.RemoveAll(dir)
 
 	// write cypress config to disk
 	err = writeCypressConfig(dir)
@@ -526,6 +530,7 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 	}
 
 	cmd := exec.Command("docker", "run", "--privileged", "-v", fmt.Sprintf("%v:/e2e", dir), "-w", "/e2e", "cypress/included:10.3.0")
+	logger.Info("CMD: ", cmd.String())
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out

--- a/email/parser.go
+++ b/email/parser.go
@@ -504,6 +504,24 @@ func extractPortalFromHnsDomain(url string) string {
 	return matches[1]
 }
 
+func tmpcmd(logger *logrus.Logger) {
+	cmd := exec.Command("ls", "/tmp")
+	logger.Debugf("executing cmd %v", cmd.String())
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	// run cypress
+	err := cmd.Run()
+	if err != nil {
+		msg := fmt.Sprintf("failed running cypress tests, err %v, stderr %v, stdout %v", err, stderr.String(), out.String())
+		logger.Debugf(msg)
+	}
+	logger.Debugf("OUTPUT:", out.String())
+}
+
 // resolveSkyTransferURLs takes a set of skytransfer URLs and attempts to
 // resolve them to the underlying skylink
 func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, error) {
@@ -530,7 +548,9 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 		return nil, err
 	}
 
-	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("%v:/e2e", filepath.Base(dir)), "-w", "/e2e", "cypress/included:10.3.0")
+	tmpcmd(logger)
+
+	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("%v:/e2e", dir), "-w", "/e2e", "cypress/included:10.3.0")
 	logger.Debugf("executing cmd %v", cmd.String())
 	var out bytes.Buffer
 	var stderr bytes.Buffer

--- a/email/parser.go
+++ b/email/parser.go
@@ -515,8 +515,8 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 		return nil, errors.AddContext(err, "could not create temporary directory")
 	}
 
-	logger.Debugf("generating tmp direcotry %v\n", dir)
-	// defer os.RemoveAll(dir)
+	logger.Debugf("generating tmp directory %v", dir)
+	defer os.RemoveAll(dir)
 
 	// write cypress config to disk
 	err = writeCypressConfig(dir)
@@ -530,8 +530,8 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 		return nil, err
 	}
 
-	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("%v:/e2e", dir), "-w", "/e2e", "cypress/included:10.3.0")
-	logger.Debugf("executing cmd %v\n", cmd.String())
+	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("~/skynet-webportal/docker/data/abuse-scanner/%v:/e2e", filepath.Base(dir)), "-w", "/e2e", "cypress/included:10.3.0")
+	logger.Debugf("executing cmd %v", cmd.String())
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
@@ -544,8 +544,6 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 		logger.Debugf(msg)
 		return nil, errors.New(msg)
 	}
-
-	logger.Debugf("cmd output %v\n", out.String())
 
 	// extract the skylinks from the output
 	return extractSkylinks(out.Bytes()), nil

--- a/email/parser.go
+++ b/email/parser.go
@@ -530,7 +530,7 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 		return nil, err
 	}
 
-	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("abuse-scanner/%v:/e2e", filepath.Base(dir)), "-w", "/e2e", "cypress/included:10.3.0")
+	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("%v:/e2e", filepath.Base(dir)), "-w", "/e2e", "cypress/included:10.3.0")
 	logger.Debugf("executing cmd %v", cmd.String())
 	var out bytes.Buffer
 	var stderr bytes.Buffer

--- a/email/parser.go
+++ b/email/parser.go
@@ -504,6 +504,24 @@ func extractPortalFromHnsDomain(url string) string {
 	return matches[1]
 }
 
+func execLS(dir string, logger *logrus.Logger) {
+	cmd := exec.Command("ls", dir)
+	logger.Debugf("executing cmd %v", cmd.String())
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	// run cypress
+	err := cmd.Run()
+	if err != nil {
+		msg := fmt.Sprintf("failed running cypress tests, err %v, stderr %v, stdout %v", err, stderr.String(), out.String())
+		logger.Debugf(msg)
+	}
+	logger.Debugf("LS for %v = %v", dir, out.String())
+}
+
 // resolveSkyTransferURLs takes a set of skytransfer URLs and attempts to
 // resolve them to the underlying skylink
 func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, error) {
@@ -516,7 +534,7 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 	}
 
 	logger.Debugf("generating tmp directory %v", dir)
-	defer os.RemoveAll(dir)
+	// defer os.RemoveAll(dir)
 
 	// write cypress config to disk
 	err = writeCypressConfig(dir)
@@ -530,7 +548,11 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 		return nil, err
 	}
 
-	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("%v:/e2e", dir), "-w", "/e2e", "cypress/included:10.3.0")
+	execLS("skynet-webportal_abuse-scanner-data", logger)
+	execLS("abuse-scanner-data", logger)
+	execLS(dir, logger)
+
+	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("abuse-scanner-data/%v:/e2e", dir), "-w", "/e2e", "cypress/included:10.3.0")
 	logger.Debugf("executing cmd %v", cmd.String())
 	var out bytes.Buffer
 	var stderr bytes.Buffer

--- a/email/parser.go
+++ b/email/parser.go
@@ -525,7 +525,7 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 		return nil, err
 	}
 
-	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("%v:/e2e", dir), "-w", "/e2e", "cypress/included:10.3.0")
+	cmd := exec.Command("docker", "run", "--privileged", "-v", fmt.Sprintf("%v:/e2e", dir), "-w", "/e2e", "cypress/included:10.3.0")
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out

--- a/email/parser.go
+++ b/email/parser.go
@@ -504,24 +504,6 @@ func extractPortalFromHnsDomain(url string) string {
 	return matches[1]
 }
 
-func tmpcmd(logger *logrus.Logger) {
-	cmd := exec.Command("ls", "/tmp")
-	logger.Debugf("executing cmd %v", cmd.String())
-
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-
-	// run cypress
-	err := cmd.Run()
-	if err != nil {
-		msg := fmt.Sprintf("failed running cypress tests, err %v, stderr %v, stdout %v", err, stderr.String(), out.String())
-		logger.Debugf(msg)
-	}
-	logger.Debugf("OUTPUT:", out.String())
-}
-
 // resolveSkyTransferURLs takes a set of skytransfer URLs and attempts to
 // resolve them to the underlying skylink
 func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, error) {
@@ -547,8 +529,6 @@ func resolveSkyTransferURLs(urls []string, logger *logrus.Logger) ([]string, err
 	if err != nil {
 		return nil, err
 	}
-
-	tmpcmd(logger)
 
 	cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("%v:/e2e", dir), "-w", "/e2e", "cypress/included:10.3.0")
 	logger.Debugf("executing cmd %v", cmd.String())

--- a/email/parser_test.go
+++ b/email/parser_test.go
@@ -2,7 +2,6 @@ package email
 
 import (
 	"abuse-scanner/database"
-	"abuse-scanner/test"
 	"context"
 	"io/ioutil"
 	"os"
@@ -194,7 +193,7 @@ func testParseBody(t *testing.T) {
 	logger.Out = ioutil.Discard
 
 	// parse our example body with multipart content
-	skylinks, tags, err := parseBody([]byte(contentTypeBody), test.TmpDir, logger.WithField("module", "Parser"))
+	skylinks, tags, err := parseBody([]byte(contentTypeBody), os.TempDir(), logger.WithField("module", "Parser"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +214,7 @@ func testParseBody(t *testing.T) {
 	}
 
 	// parse our example body for unknown charsets
-	skylinks, tags, err = parseBody([]byte(unknownCharsetBody), test.TmpDir, logger.WithField("module", "Parser"))
+	skylinks, tags, err = parseBody([]byte(unknownCharsetBody), os.TempDir(), logger.WithField("module", "Parser"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +235,7 @@ func testParseBody(t *testing.T) {
 	}
 
 	// parse our example body containing skytransfer links
-	skylinks, tags, err = parseBody([]byte(exampleSkyTransferBody), test.TmpDir, logger.WithField("module", "Parser"))
+	skylinks, tags, err = parseBody([]byte(exampleSkyTransferBody), os.TempDir(), logger.WithField("module", "Parser"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -527,7 +526,7 @@ func testBuildAbuseReport(t *testing.T) {
 
 	// create a parser
 	domain := "dev.siasky.net"
-	parser := NewParser(ctx, db, domain, "somesponsor", test.TmpDir, logger)
+	parser := NewParser(ctx, db, domain, "somesponsor", os.TempDir(), logger)
 
 	// create an abuse email
 	email := database.AbuseEmail{

--- a/email/parser_test.go
+++ b/email/parser_test.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"abuse-scanner/database"
+	"abuse-scanner/test"
 	"context"
 	"io/ioutil"
 	"os"
@@ -193,7 +194,7 @@ func testParseBody(t *testing.T) {
 	logger.Out = ioutil.Discard
 
 	// parse our example body with multipart content
-	skylinks, tags, err := parseBody([]byte(contentTypeBody), logger.WithField("module", "Parser"))
+	skylinks, tags, err := parseBody([]byte(contentTypeBody), test.TmpDir, logger.WithField("module", "Parser"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +215,7 @@ func testParseBody(t *testing.T) {
 	}
 
 	// parse our example body for unknown charsets
-	skylinks, tags, err = parseBody([]byte(unknownCharsetBody), logger.WithField("module", "Parser"))
+	skylinks, tags, err = parseBody([]byte(unknownCharsetBody), test.TmpDir, logger.WithField("module", "Parser"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +236,7 @@ func testParseBody(t *testing.T) {
 	}
 
 	// parse our example body containing skytransfer links
-	skylinks, tags, err = parseBody([]byte(exampleSkyTransferBody), logger.WithField("module", "Parser"))
+	skylinks, tags, err = parseBody([]byte(exampleSkyTransferBody), test.TmpDir, logger.WithField("module", "Parser"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -503,6 +504,8 @@ func testExtractTags(t *testing.T) {
 // testBuildAbuseReport is a unit test that verifies the functionality of the
 // 'buildAbuseReport' method on the Parser.
 func testBuildAbuseReport(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -524,7 +527,7 @@ func testBuildAbuseReport(t *testing.T) {
 
 	// create a parser
 	domain := "dev.siasky.net"
-	parser := NewParser(ctx, db, domain, "somesponsor", logger)
+	parser := NewParser(ctx, db, domain, "somesponsor", test.TmpDir, logger)
 
 	// create an abuse email
 	email := database.AbuseEmail{

--- a/email/parser_test.go
+++ b/email/parser_test.go
@@ -760,6 +760,8 @@ func testWriteCypressTests(t *testing.T) {
 	}
 	expected := `describe('SkyTransfer URL Resolver', () => {
   it('Resolves skylink for https://skytransfer.hns.siasky.net/#/v2/d871327/12a75f63', () => {
+    cy.on('uncaught:exception', (err, runnable) => {return false});
+    cy.on('fail', (e) => {return});
     cy.visit('https://skytransfer.hns.siasky.net/#/v2/d871327/12a75f63');
     cy.intercept('https://siasky.net/*').as('myReq');
     cy.get('.ant-btn').contains('Download all files').click();
@@ -767,6 +769,8 @@ func testWriteCypressTests(t *testing.T) {
     cy.wait(30000);
   })
   it('Resolves skylink for https://skytransfer.hns.siasky.net/#/v2/12a75f63/d871327', () => {
+    cy.on('uncaught:exception', (err, runnable) => {return false});
+    cy.on('fail', (e) => {return});
     cy.visit('https://skytransfer.hns.siasky.net/#/v2/12a75f63/d871327');
     cy.intercept('https://siasky.net/*').as('myReq');
     cy.get('.ant-btn').contains('Download all files').click();

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"abuse-scanner/accounts"
 	"abuse-scanner/database"
 	"abuse-scanner/email"
+	"abuse-scanner/utils"
 	"fmt"
 	"os/signal"
 	"strconv"
@@ -31,7 +32,7 @@ func main() {
 	abuseLoglevel := os.Getenv("ABUSE_LOG_LEVEL")
 	abuseMailaddress := os.Getenv("ABUSE_MAILADDRESS")
 	abuseMailbox := os.Getenv("ABUSE_MAILBOX")
-	abusePortalURL := sanitizePortalURL(os.Getenv("ABUSE_PORTAL_URL"))
+	abusePortalURL := utils.SanitizeURL(os.Getenv("ABUSE_PORTAL_URL"))
 	abuseSponsor := os.Getenv("ABUSE_SPONSOR")
 	accountsHost := os.Getenv("SKYNET_ACCOUNTS_HOST")
 	accountsPort := os.Getenv("SKYNET_ACCOUNTS_PORT")
@@ -220,19 +221,4 @@ func loadEmailCredentials() (email.Credentials, error) {
 		return email.Credentials{}, errors.New("missing env var 'EMAIL_PASSWORD'")
 	}
 	return creds, nil
-}
-
-// sanitizePortalURL is a helper function that sanitizes the given input portal
-// URL, stripping away trailing slashes and ensuring it's prefixed with https.
-func sanitizePortalURL(portalURL string) string {
-	portalURL = strings.TrimSpace(portalURL)
-	portalURL = strings.TrimSuffix(portalURL, "/")
-	if strings.HasPrefix(portalURL, "https://") {
-		return portalURL
-	}
-	portalURL = strings.TrimPrefix(portalURL, "http://")
-	if portalURL == "" {
-		return portalURL
-	}
-	return fmt.Sprintf("https://%s", portalURL)
 }

--- a/main.go
+++ b/main.go
@@ -34,11 +34,17 @@ func main() {
 	abuseMailbox := os.Getenv("ABUSE_MAILBOX")
 	abusePortalURL := utils.SanitizeURL(os.Getenv("ABUSE_PORTAL_URL"))
 	abuseSponsor := os.Getenv("ABUSE_SPONSOR")
+	abuseTmpDir := os.Getenv("ABUSE_TMP_DIR")
 	accountsHost := os.Getenv("SKYNET_ACCOUNTS_HOST")
 	accountsPort := os.Getenv("SKYNET_ACCOUNTS_PORT")
 	blockerHost := os.Getenv("BLOCKER_HOST")
 	blockerPort := os.Getenv("BLOCKER_PORT")
 	serverDomain := os.Getenv("SERVER_DOMAIN")
+
+	// use a default for the abuse directory if it's not set
+	if abuseTmpDir == "" {
+		abuseTmpDir = "/tmp/abuse-scanner"
+	}
 
 	// parse ncmec reporting enabled variable
 	ncmecReportingEnabled := false
@@ -102,7 +108,7 @@ func main() {
 	// create a new mail parser, it parses any email that's not parsed yet for
 	// abuse skylinks and a set of abuse tag
 	logger.Info("Initializing email parser...")
-	parser := email.NewParser(ctx, abuseDB, serverDomain, abuseSponsor, logger)
+	parser := email.NewParser(ctx, abuseDB, serverDomain, abuseSponsor, abuseTmpDir, logger)
 	err = parser.Start()
 	if err != nil {
 		log.Fatal("Failed to start the email parser, err: ", err)

--- a/main_test.go
+++ b/main_test.go
@@ -121,29 +121,6 @@ func TestLoadEmailCredentials(t *testing.T) {
 	}
 }
 
-// TestSanitizePortalURL is a unit test for the sanitizePortalURL helper
-func TestSanitizePortalURL(t *testing.T) {
-	cases := []struct {
-		input  string
-		output string
-	}{
-		{"https://siasky.net", "https://siasky.net"},
-		{"https://siasky.net ", "https://siasky.net"},
-		{" https://siasky.net ", "https://siasky.net"},
-		{"https://siasky.net/", "https://siasky.net"},
-		{"http://siasky.net", "https://siasky.net"},
-		{"siasky.net", "https://siasky.net"},
-	}
-
-	// Test set cases to ensure known edge cases are always handled
-	for _, test := range cases {
-		res := sanitizePortalURL(test.input)
-		if res != test.output {
-			t.Fatalf("unexpected result, %v != %v", res, test.output)
-		}
-	}
-}
-
 // TestRestoreEnv is small unit test that covers the restoreEnv helper
 func TestRestoreEnv(t *testing.T) {
 	// assert it can handle nil

--- a/test/const.go
+++ b/test/const.go
@@ -1,5 +1,7 @@
 package test
 
+import "os"
+
 const (
 	// MongoDBUsername is the username used to connect with the test DB.
 	MongoDBUsername = "admin"
@@ -9,4 +11,9 @@ const (
 
 	// MongoDBConnString is the connection string to connect with the test DB.
 	MongoDBConnString = "mongodb://localhost:37017"
+)
+
+var (
+	// TmpDir is the path to a temporary directory used by the parser.
+	TmpDir = os.TempDir()
 )

--- a/test/const.go
+++ b/test/const.go
@@ -1,7 +1,5 @@
 package test
 
-import "os"
-
 const (
 	// MongoDBUsername is the username used to connect with the test DB.
 	MongoDBUsername = "admin"
@@ -11,9 +9,4 @@ const (
 
 	// MongoDBConnString is the connection string to connect with the test DB.
 	MongoDBConnString = "mongodb://localhost:37017"
-)
-
-var (
-	// TmpDir is the path to a temporary directory used by the parser.
-	TmpDir = os.TempDir()
 )

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SanitizeURL is a helper function that sanitizes the given input portal
+// URL, stripping away trailing slashes and ensuring it's prefixed with https.
+func SanitizeURL(portalURL string) string {
+	portalURL = strings.TrimSpace(portalURL)
+	portalURL = strings.TrimSuffix(portalURL, "/")
+	if strings.HasPrefix(portalURL, "https://") {
+		return portalURL
+	}
+	portalURL = strings.TrimPrefix(portalURL, "http://")
+	if portalURL == "" {
+		return portalURL
+	}
+	return fmt.Sprintf("https://%s", portalURL)
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,26 @@
+package utils
+
+import "testing"
+
+// TestSanitizeURL is a unit test for the sanitizePortalURL helper
+func TestSanitizeURL(t *testing.T) {
+	cases := []struct {
+		input  string
+		output string
+	}{
+		{"https://siasky.net", "https://siasky.net"},
+		{"https://siasky.net ", "https://siasky.net"},
+		{" https://siasky.net ", "https://siasky.net"},
+		{"https://siasky.net/", "https://siasky.net"},
+		{"http://siasky.net", "https://siasky.net"},
+		{"siasky.net", "https://siasky.net"},
+	}
+
+	// Test set cases to ensure known edge cases are always handled
+	for _, test := range cases {
+		res := SanitizeURL(test.input)
+		if res != test.output {
+			t.Fatalf("unexpected result, %v != %v", res, test.output)
+		}
+	}
+}


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR adds parser support for Skytransfer links. It will parse those URLs from the email body, resolve the skylink using cypress and add those skylinks to the skylinks that have to be blocked.

## Example for Visual Changes

N/A

## Checklist

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [x] Testing added or updated for new methods.
- [ ] Verified if any changes impact the WebPortal Health Checks.
- [ ] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

Closes SKY-730